### PR TITLE
Improve status messages on confirmation

### DIFF
--- a/lib/hex_web/web/templates/confirm.html.eex
+++ b/lib/hex_web/web/templates/confirm.html.eex
@@ -1,5 +1,15 @@
 <%= if @success do %>
-  <h2>Account confirmed</h2>
+  <h2 class="text-success">Account confirmed</h2>
+  <h3>
+    Your account has been confirmed, you now have full access to your account at Hex.pm
+  </h3>
 <% else %>
-  <h2>Failed to confirm account</h2>
+  <h2 class="text-danger">Failed to confirm account</h2>
+  <h3>
+    We could not confirm your account. Please check the URL and try again.
+
+    <small>
+      If you believe there is an error, feel free to email <a href="mailto:support@hex.pm">support</a>, or leave an issue on <a href="https://github.com/hexpm">GitHub</a>.
+    </small>
+  </h3>
 <% end %>


### PR DESCRIPTION
This pull request updates the confirm template, making the response clearer, particularly when it comes to confirmation errors.

|state|screenshot|
|-------|--------------|
|success|![screen shot 2015-01-01 at 9 07 41 pm](https://cloud.githubusercontent.com/assets/860934/5591982/1895d42e-91fa-11e4-87c0-331ff3597ef0.png)|
|failure|![screen shot 2015-01-01 at 9 07 56 pm](https://cloud.githubusercontent.com/assets/860934/5591983/1e85df64-91fa-11e4-9a4e-8c4339296eef.png)|

Note: this is for the `/confirm` route, *not* email templates.