### PR TITLE
Accept database specification for all environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,23 @@ This is located in the "postgresql-contrib" package, however the package name ca
 
 ### Database
 
-HexWeb connects to a localhost postgresql database `hex_dev` using the username `postgresql` with the password `postgresql`. Create this database/user if not already done:
+By default, HexWeb connects to a localhost PostgreSQL database `hexweb_dev` using the username `postgres` with the password `postgres`.
+
+Create the database and user 'postgres' if not already done:
 
 ```sql
 CREATE USER postgres;
 ALTER USER postgres PASSWORD 'postgres';
-CREATE DATABASE hex_dev;
-GRANT ALL PRIVILEGES ON DATABASE hex_dev TO postgres;
+CREATE DATABASE hexweb_dev;
+GRANT ALL PRIVILEGES ON DATABASE hexweb_dev TO postgres;
 ALTER USER postgres WITH SUPERUSER;
+```
+
+If you want to use another database, user or password, you can specify the
+`DEV_DATABASE_URL` in the shell before doing development:
+
+```shell
+export DEV_DATABASE_URL=ecto://USER:PASSWORD@localhost/DATABASE
 ```
 
 Now you are fine to run the ecto migrations:
@@ -53,3 +62,14 @@ mix run --no-halt
 ```
 
 HexWeb will be available at [http://localhost:4000/](http://localhost:4000/).
+
+### Running Tests
+
+By default, tests use a PostgreSQL called `hexweb_test` see above for setup.
+
+Again, if you want to use another database, user or password, you can specify the
+`TEST_DATABASE_URL` in the shell before running tests:
+
+```shell
+export TEST_DATABASE_URL='ecto://USER:PASSWORD@localhost/DATABASE'
+```

--- a/config/config.exs
+++ b/config/config.exs
@@ -43,6 +43,17 @@ if Mix.env in [:dev, :test] do
     secret:   System.get_env("HEX_SECRET")   || "796f75666f756e64746865686578"
 end
 
+case Mix.env do
+  :prod ->
+    config :hex_web,
+      database_url: System.get_env("DATABASE_URL")
+  :dev ->
+    config :hex_web,
+      database_url: System.get_env("DEV_DATABASE_URL") || "ecto://postgres:postgres@localhost/hexweb_dev"
+  :test ->
+    config :hex_web,
+      database_url: System.get_env("TEST_DATABASE_URL") || "ecto://postgres:postgres@localhost/hexweb_test"
+end
 
 config :logger,
   level: log_level

--- a/lib/hex_web/repo.ex
+++ b/lib/hex_web/repo.ex
@@ -1,14 +1,16 @@
 defmodule HexWeb.Repo do
   use Ecto.Repo, adapter: Ecto.Adapters.Postgres, env: Mix.env
 
-  def conf(:prod),
-    do: parse_url(System.get_env("DATABASE_URL")) ++ [lazy: false]
-
-  def conf(:dev),
-    do: parse_url "ecto://postgres:postgres@localhost/hexweb_dev"
-
-  def conf(:test),
-    do: parse_url "ecto://postgres:postgres@localhost/hexweb_test?size=1&max_overflow=0"
+  def conf(env) do
+    case env do
+      :prod ->
+        parse_url(Application.get_env(:hex_web, :database_url)) ++ [lazy: false]
+      :dev ->
+        parse_url Application.get_env(:hex_web, :database_url)
+      :test ->
+        parse_url(Application.get_env(:hex_web, :database_url)) ++ [size: "1", max_overflow: "0"]
+    end
+  end
 
   def priv,
     do: :code.priv_dir(:hex_web)


### PR DESCRIPTION
* users can override the default database name, username and password
  when in dev and test mode by setting environment variables,
  * for dev, set DEV_DATABASE_URL,
  * for test, set TEST_DATABASE_URL,
* the variables are different so that tests can be run against a
  different database to the one used for dev,
* as tests need to be run via a single pooled connection, the test
  params have size=1 and max_overflow=0 set as overrides.