### PR TITLE
Add the ability to reset password via email

### DIFF
--- a/lib/hex_web/api/router.ex
+++ b/lib/hex_web/api/router.ex
@@ -168,6 +168,15 @@ defmodule HexWeb.API.Router do
       end)
     end
 
+    post "users/:name/reset" do
+      if (user = User.get(username: name) || User.get(email: name)) do
+        User.initiate_password_reset(user)
+        send_okay(conn, user, :public)
+      else
+        raise NotFound
+      end
+    end
+
     get "packages" do
       page = parse_integer(conn.params["page"], 1)
       packages = Package.all(page, 100, conn.params["search"])

--- a/lib/hex_web/email/templates.ex
+++ b/lib/hex_web/email/templates.ex
@@ -14,7 +14,9 @@ defmodule HexWeb.Email.Templates do
   @templates [
     main: [:name, :assigns],
     confirmation_request: [:assigns],
-    confirmed: [:_]
+    confirmed: [:_],
+    password_reset_request: [:assigns],
+    password_reset: [:_]
   ]
 
   Enum.each(@templates, fn {name, args} ->

--- a/lib/hex_web/email/templates/password_reset.html.eex
+++ b/lib/hex_web/email/templates/password_reset.html.eex
@@ -1,0 +1,18 @@
+<h2>Your Hex.pm password has been reset</h2>
+
+<p>
+  Your account password has been reset, you have full access to your account at Hex.pm.
+</p>
+
+<p>
+  <strong>Note</strong>: Your existing keys have been invalidated, so you will need to regenerate them by running:
+  <br/>
+  <pre>mix hex.user auth</pre>
+  
+  and entering your username and password.
+</p>
+
+<p>
+  --<br>
+  The Hex.pm team
+</p>

--- a/lib/hex_web/email/templates/password_reset_request.html.eex
+++ b/lib/hex_web/email/templates/password_reset_request.html.eex
@@ -1,0 +1,34 @@
+<%
+reset_url = HexWeb.Util.url("reset?username=#{@username}&key=#{@key}")
+%>
+
+<h2>Reset your Hex.pm password</h2>
+
+<p>
+  We heard you've lost your password to Hex.pm. Sorry about that!
+</p>
+
+<p>
+  You can reset your password by following <a href="<%= safe reset_url %>">this link</a> or by pasting the link below in your web browser.
+</p>
+
+<p>
+  <%= safe reset_url %>
+</p>
+
+<p>
+  Once this is complete, your existing keys will be invalidated, so you will need to regenerate them by running: 
+  
+  <pre>mix hex.user auth</pre>
+  
+  and entering your username and password.
+</p>
+
+<p>
+  (Please note that this URL is only valid for the next 24 hours.)
+</p>
+
+<p>
+  --<br>
+  The Hex.pm team
+</p>

--- a/lib/hex_web/util.ex
+++ b/lib/hex_web/util.ex
@@ -24,6 +24,22 @@ defmodule HexWeb.Util do
     Ecto.DateTime.from_erl(:calendar.universal_time)
   end
 
+  defp diff(a, b) do
+    {days, time} = :calendar.time_difference(a, b)
+    :calendar.time_to_seconds(time) - (days * 24 * 60 * 60)
+  end
+
+  @doc """
+  Determine if a given timestamp is less than a day (86400 seconds) old
+  """
+  def within_last_day(nil), do: false
+  def within_last_day(a) do
+    diff = diff(Ecto.DateTime.to_erl(a),
+                :calendar.universal_time)
+
+    diff < (24 * 60 * 60)
+  end
+
   def etag(nil), do: nil
   def etag([]),  do: nil
 

--- a/lib/hex_web/web/router.ex
+++ b/lib/hex_web/web/router.ex
@@ -15,6 +15,7 @@ defmodule HexWeb.Web.Router do
 
   @packages 30
 
+  plug Plug.Parsers, parsers: [:urlencoded, :multipart]
   plug :match
   plug :dispatch
 
@@ -40,6 +41,27 @@ defmodule HexWeb.Web.Router do
 
     conn = assign_pun(conn, [success])
     send_page(conn, :confirm)
+  end
+
+  get "reset" do
+    conn = fetch_params(conn)
+
+    name = conn.params["username"]
+    key  = conn.params["key"]
+
+    conn = assign_pun(conn, [name, key])
+    send_page(conn, :reset)
+  end
+
+  post "reset" do
+    name     = conn.params["username"]
+    key      = conn.params["key"]
+    password = conn.params["password"]
+
+    success = User.reset?(name, key, password)
+
+    conn = assign_pun(conn, [success])
+    send_page(conn, :resetresult)
   end
 
   get "docs/usage" do

--- a/lib/hex_web/web/templates.ex
+++ b/lib/hex_web/web/templates.ex
@@ -33,6 +33,8 @@ defmodule HexWeb.Web.Templates do
     docs_publish: [:_],
     docs_tasks: [:_],
     docs_codeofconduct: [:_],
+    reset: [:assigns],
+    resetresult: [:assigns]
   ]
 
   Enum.each(@templates, fn {name, args} ->

--- a/lib/hex_web/web/templates/main.html.eex
+++ b/lib/hex_web/web/templates/main.html.eex
@@ -22,10 +22,12 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-		  <a class="navbar-brand" href="/">
-			  <span style="font-size: 24px;">⬢</span>&nbsp;Hex
-		  </a>
-       </div>
+
+          <a class="navbar-brand" href="/">
+			      <span style="font-size: 24px;">⬢</span>&nbsp;Hex
+		      </a>
+        </div>
+
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
             <li<%= if @active == :packages do %> class="active" <% end %>><a href="/packages">Packages</a></li>
@@ -37,12 +39,13 @@
                 <li><a href="/docs/tasks">Mix tasks</a></li>
               </ul>
             </li>
-		</ul>
-   		 <form class="navbar-form navbar-right" role="search" action="/packages" method="get">
+          </ul>
+
+   		    <form class="navbar-form navbar-right" role="search" action="/packages" method="get">
             <div class="input-group">
-				<input type="search" class="form-control" id="inputSearchPackages" placeholder="Search packages" name="search" value="<%= @search %>">
-				<label class="sr-only" for="inputSearchPackages">Search packages</label>
-				<span class="input-group-btn"><button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-search"></span></button></span>
+				      <input type="search" class="form-control" id="inputSearchPackages" placeholder="Search packages" name="search" value="<%= @search %>">
+				      <label class="sr-only" for="inputSearchPackages">Search packages</label>
+				      <span class="input-group-btn"><button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-search"></span></button></span>
             </div>
           </form>
         </div>

--- a/lib/hex_web/web/templates/reset.html.eex
+++ b/lib/hex_web/web/templates/reset.html.eex
@@ -1,0 +1,50 @@
+<script>
+function validate() { 
+  var form = document.forms["reset_form"];
+  
+  var empty = function(form, name) {
+    return form[name].value == "" || form[name].value == null
+  };
+
+  var message = function(message) {
+    var div = document.getElementById("error");
+    div.innerHTML = message;
+  };
+
+  if(empty(form, "password") || empty(form, "confirm_password")) {
+    message("Fields cannot be left blank!")
+    return false;
+  } else if(form["confirm_password"].value != form["password"].value) {
+    message("Passwords do not match!");
+    return false;
+  } else {
+    message("");
+    return true;
+  }
+}
+</script>
+
+<div class="row">
+  <div class="col-md-8 col-md-offset-2">
+    <form name="reset_form" action="/reset" onsubmit="return validate();" method="post">
+      <h2>Reset your Hex.pm password</h2>
+
+      <p class="text-warning" id="error"></p>
+
+      <div class="form-group">
+        <label for="password">Password <strong>*</strong></label>
+        <input type="password" class="form-control" name="password" placeholder="Password">
+      </div>
+
+      <div class="form-group">
+        <label for="confirm_password">Confirm Password <strong>*</strong></label>
+        <input type="password" class="form-control" name="confirm_password" placeholder="Confirm Password">
+      </div>
+
+      <input type="hidden" name="username" value="<%= @name %>">
+      <input type="hidden" name="key" value="<%= @key %>">
+
+      <button type="submit" class="btn btn-default">Submit</button>
+    </form>
+  </div>
+</div>

--- a/lib/hex_web/web/templates/resetresult.html.eex
+++ b/lib/hex_web/web/templates/resetresult.html.eex
@@ -1,0 +1,15 @@
+<%= if @success do %>
+  <h2 class="text-success">Password reset</h2>
+  <h3>
+    Your account password has been reset, you now have full access to your account at Hex.pm
+  </h3>
+<% else %>
+  <h2 class="text-danger">Failed to reset account password</h2>
+  <h3>
+    We could not reset the password to your account. Please check the URL and try again.
+
+    <small>
+      If you believe there is an error, feel free to email <a href="mailto:support@hex.pm">support</a>, or leave an issue on <a href="https://github.com/hexpm">GitHub</a>.
+    </small>
+  </h3>
+<% end %>

--- a/priv/migrations/20150117064046_reset_key.exs
+++ b/priv/migrations/20150117064046_reset_key.exs
@@ -1,0 +1,15 @@
+defmodule HexWeb.Repo.Migrations.ResetKey do
+  use Ecto.Migration
+
+  def up do
+    "ALTER TABLE users
+      ADD COLUMN reset_key text,
+      ADD COLUMN reset_expiry timestamp"
+  end
+
+  def down do
+    "ALTER TABLE users
+      DROP COLUMN IF EXISTS reset_key,
+      DROP COLUMN IF EXISTS reset_expiry"
+  end
+end


### PR DESCRIPTION
Closes #22 

This is something I've been wanting to complete for a while! Sorry for the wait.

TODO:
- [x] Some things might need rewording (emails and result pages (`/reset`))
  - Currently, reset tokens only last 24 hours. This needs to be included in the email.
- [x] I also need to validate the form (pretty much just password == confirm_password)
- [ ] Client side implementation

Let me know what you think of the pull request so far!

/cc @ericmj @josevalim 