### PR TITLE
Don't return a user object on account reset

### DIFF
--- a/lib/hex_web/api/router.ex
+++ b/lib/hex_web/api/router.ex
@@ -171,7 +171,10 @@ defmodule HexWeb.API.Router do
     post "users/:name/reset" do
       if (user = User.get(username: name) || User.get(email: name)) do
         User.initiate_password_reset(user)
-        send_okay(conn, user, :public)
+
+        conn
+        |> cache(:private)
+        |> send_resp(204, "")
       else
         raise NotFound
       end


### PR DESCRIPTION
*Note:* Referring to the same fix for `/api/users/:user/` (da5d508)

This fixes `/api/users/:user/reset` to not return the user object. There's no need to return the user object in this route, and shouldn't be returned unless the user is authenticated anyway.

:lock: