### PR TITLE
Remove PATCH user/:name

### DIFF
--- a/lib/hex_web/api/router.ex
+++ b/lib/hex_web/api/router.ex
@@ -183,13 +183,6 @@ defmodule HexWeb.API.Router do
       end)
     end
 
-    patch "users/:name" do
-      with_authorized(conn, [only_basic: true], &(&1.username == name), fn user ->
-        result = User.update(user, conn.params["email"], conn.params["password"])
-        send_update_resp(conn, result, :public)
-      end)
-    end
-
     post "users/:name/reset" do
       if (user = User.get(username: name) || User.get(email: name)) do
         User.initiate_password_reset(user)

--- a/test/hex_web/api/router_test.exs
+++ b/test/hex_web/api/router_test.exs
@@ -79,44 +79,6 @@ defmodule HexWeb.API.RouterTest do
     refute User.get(username: "name")
   end
 
-  test "update user" do
-    headers = [ {"content-type", "application/json"},
-                {"authorization", "Basic " <> :base64.encode("other:other")}]
-    body = %{email: "email@mail.com", password: "pass"}
-    conn = conn("PATCH", "/api/users/other", Poison.encode!(body), headers: headers)
-    conn = Router.call(conn, [])
-
-    assert conn.status == 200
-    body = Poison.decode!(conn.resp_body)
-    assert body["url"] == "http://localhost:4000/api/users/other"
-    user = assert User.get(username: "other")
-    assert user.email == "email@mail.com"
-
-    headers = [ {"content-type", "application/json"},
-                {"authorization", "Basic " <> :base64.encode("other:pass")}]
-    body = %{username: "foo"}
-    conn = conn("PATCH", "/api/users/other", Poison.encode!(body), headers: headers)
-    conn = Router.call(conn, [])
-
-    assert conn.status == 200
-    body = Poison.decode!(conn.resp_body)
-    assert body["url"] == "http://localhost:4000/api/users/other"
-    assert User.get(username: "other")
-    refute User.get(username: "foo")
-  end
-
-  test "update user only basic auth" do
-    user = User.get(username: "other")
-    {:ok, key} = Key.create("macbook", user)
-
-    headers = [ {"content-type", "application/json"},
-                {"authorization", key.user_secret}]
-    body = %{email: "email@mail.com", password: "pass"}
-    conn = conn("PATCH", "/api/users/other", Poison.encode!(body), headers: headers)
-    conn = Router.call(conn, [])
-    assert conn.status == 401
-  end
-
   test "create package with key auth" do
     user = User.get(username: "eric")
     {:ok, key} = Key.create("macbook", user)


### PR DESCRIPTION
:warning: To be merged after March 15th, 2015 :warning: 

This PR removes the ability to update a user by calling `PATCH user/:name`, which was superseded  by password resets, therefore rendering `PATCH user/:name` a security risk.

The relevant tests have also been removed.

:leaves: :fallen_leaf: 