### PR TITLE
Include reason why authentication failed

### DIFF
--- a/test/hex_web/api/router_test.exs
+++ b/test/hex_web/api/router_test.exs
@@ -51,7 +51,8 @@ defmodule HexWeb.API.RouterTest do
     body = %{meta: %{}}
     conn = conn("PUT", "/api/packages/ecto", Poison.encode!(body), headers: headers)
     conn = Router.call(conn, [])
-    assert conn.status == 401
+    assert conn.status == 403
+    assert conn.resp_body =~ "Account Unconfirmed"
 
     conn = conn("GET", "/confirm?username=name&key=" <> user.confirmation_key)
     conn = Router.call(conn, [])


### PR DESCRIPTION
I think this should fix #103.

Instead of adding a body to the error response, I've used a 402 request for unconfirmed error responses.

This is backwards compatible with existing clients, as they match any request with a status code between 400-499 as an error.

If you think this is all good, I'll open a PR on the client adding a clause for unconfirmed error responses.