### PR TITLE
default to HTTPS for HEX_S3_URL

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,7 @@ config :hex_web,
   url:           System.get_env("HEX_URL"),
   app_host:      System.get_env("APP_HOST"),
 
-  s3_url:        System.get_env("HEX_S3_URL") || "http://s3.amazonaws.com",
+  s3_url:        System.get_env("HEX_S3_URL") || "https://s3.amazonaws.com",
   s3_bucket:     System.get_env("HEX_S3_BUCKET"),
   s3_access_key: System.get_env("HEX_S3_ACCESS_KEY"),
   s3_secret_key: System.get_env("HEX_S3_SECRET_KEY"),


### PR DESCRIPTION
Hi, I'm brand new to Elixir and Hex. One of the first things I noticed when getting up and running on a Phoenix project is that when installing rebar, hex makes an unencrypted HTTP connection to `s3.hex.pm` (or maybe just `s3.amazonaws.com`).

![screen shot 2015-06-23 at 8 42 50 am](https://cloud.githubusercontent.com/assets/114033/8310435/b1665dc4-1984-11e5-9268-863e320dbb96.png)
![screen shot 2015-06-23 at 8 42 34 am](https://cloud.githubusercontent.com/assets/114033/8310436/b1694a20-1984-11e5-9116-716ba06cfa1f.png)

Is there any reason not to be using HTTPS for everything Hex does? While Hex may be doing all the right things to verify package integrity (not that I've verified this yet), plain HTTP still leaks more metadata than necessary and offers the opportunity for intermediaries (read: captive portals, hotel + airplane wifi) to mess with Hex's traffic.

I dug through the source of hex and hex_web a bit, but the only obvious culprit I could find was this default config setting on hex_web. Is this the right place to make this change so that Hex only communicates with S3 over HTTPS?