### PR TITLE
Fix a typo

### DIFF
--- a/lib/hex_web/email/templates/publish_success.html.eex
+++ b/lib/hex_web/email/templates/publish_success.html.eex
@@ -1,5 +1,5 @@
 <p>
-  The <%= if @docs do %>documentation for<% else %>release<% end %> <%= @packagee %> v<%= @version %> has been published, and is now available on Hex.pm.
+  The <%= if @docs do %>documentation for<% else %>release<% end %> <%= @package %> v<%= @version %> has been published, and is now available on Hex.pm.
 </p>
 
 <p>


### PR DESCRIPTION
Fixes a typo in the `@package` variable of the publish_success email template.