### PR TITLE
Add user page that shows user's packages

### DIFF
--- a/lib/hex_web/user.ex
+++ b/lib/hex_web/user.ex
@@ -137,6 +137,13 @@ defmodule HexWeb.User do
     |> HexWeb.Repo.one
   end
 
+  def get(id: id) do
+    from(u in HexWeb.User,
+         where: u.id == ^id,
+         limit: 1)
+    |> HexWeb.Repo.one
+  end
+
   def delete(user) do
     HexWeb.Repo.delete(user)
   end
@@ -150,6 +157,16 @@ defmodule HexWeb.User do
     hash        = :erlang.list_to_binary(hash)
 
     Util.secure_compare(hash, stored_hash)
+  end
+
+  def packages(user) do
+    from(p in HexWeb.Package,
+         join: po in HexWeb.PackageOwner, on: p.id == po.package_id,
+         where: po.owner_id == ^user.id,
+         left_join: d in HexWeb.Stats.PackageDownload, on: p.id == d.package_id and d.view == "all",
+         order_by: [asc: is_nil(d.downloads), desc: d.downloads],
+         select: p)
+    |> HexWeb.Repo.all
   end
 
   defp delete_keys(changeset) do

--- a/lib/hex_web/web/templates.ex
+++ b/lib/hex_web/web/templates.ex
@@ -35,7 +35,8 @@ defmodule HexWeb.Web.Templates do
     docs_codeofconduct: [:_],
     reset: [:assigns],
     resetresult: [:assigns],
-    versions: [:package, :releases]
+    versions: [:package, :releases],
+    user: [:assigns]
   ]
 
   Enum.each(@templates, fn {name, args} ->

--- a/lib/hex_web/web/templates/package.html.eex
+++ b/lib/hex_web/web/templates/package.html.eex
@@ -49,6 +49,19 @@ build_tools = @current_release && @current_release.meta["build_tools"] || []
           </ul>
         </dd>
       <% end %>
+
+      <%= if @owners != [] do %>
+        <dt>Owners</dt>
+        <dd>
+          <ul class="list-unstyled">
+            <%= for owner <- @owners do %>
+              <li>
+                <a href="<%= "/users/#{owner.id}" %>"><%= owner.username %></a>
+              </li>
+            <% end %>
+          </ul>
+        </dd>
+      <% end %>
     </dl>
   </div>
   <div class="col-sm-4">

--- a/lib/hex_web/web/templates/user.html.eex
+++ b/lib/hex_web/web/templates/user.html.eex
@@ -1,0 +1,38 @@
+<%
+package_count = length(@packages)
+%>
+
+<div class="page-header" style="margin-top: 0;">
+  <h2><%= @user.username %></h2>
+  <span class="description">total packages <%= package_count %></span>
+</div>
+
+<table class="table table-striped packages">
+  <thead>
+    <tr>
+      <th style="width: 10em;">Name</th>
+      <th>Description</th>
+      <th style="width: 5em;">Latest</th>
+      <th style="width: 7em; text-align: right;">Downloads</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= for package <- @packages do %>
+      <tr>
+        <td>
+          <a href="/packages/<%= package.name %>">
+            <span class="glyphicon glyphicon-folder-open" style="padding-right: 0.5em;"></span><%= package.name %>
+          </a>
+        </td>
+        <td><%= text_length(package.meta["description"], 140) %></td>
+        <td>
+          <span class="text-muted"><%= package.latest_version %></span>
+        </td>
+        <td style="text-align: right;">
+          <span class="text-muted" style="padding-right: 10px;"><%= human_number_space(@downloads[package.id] || 0) %></span>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"aws_auth": {:hex, :aws_auth, "0.2.3"},
-  "bcrypt": {:git, "https://github.com/opscode/erlang-bcrypt.git", "7515e80a5e16f62aef149709f6cc09995dd480be", []},
+  "bcrypt": {:git, "git://github.com/opscode/erlang-bcrypt.git", "5cbe6becbe926739adebc67c6827ac2a2b9e7bbd", []},
   "cowboy": {:hex, :cowboy, "1.0.0"},
   "cowlib": {:hex, :cowlib, "1.0.1"},
   "decimal": {:hex, :decimal, "1.1.0"},

--- a/test/hex_web/user_test.exs
+++ b/test/hex_web/user_test.exs
@@ -2,6 +2,7 @@ defmodule HexWeb.UserTest do
   use HexWebTest.Case
 
   alias HexWeb.User
+  alias HexWeb.Package
 
   test "create user and auth" do
     assert {:ok, %User{}} = User.create(%{username: "eric", email: "eric@mail.com", password: "hunter42"}, true)
@@ -27,5 +28,18 @@ defmodule HexWeb.UserTest do
     user = User.get(username: "eric")
     assert User.auth?(user, "new_pass")
     refute User.auth?(user, "erics_pass")
+  end
+
+  test "get" do
+    {:ok, user} = User.create(%{username: "joe", email: "joe@example.com", password: "joe"}, true)
+    assert User.get(username: "joe").username == "joe"
+    assert User.get(email: "joe@example.com").username == "joe"
+    assert User.get(id: user.id).username == "joe"
+  end
+
+  test "packages" do
+    {:ok, user} = User.create(%{username: "joe", email: "joe@example.com", password: "joe"}, true)
+    {:ok, package} = Package.create(user, pkg_meta(%{name: "joe_package"}))
+    assert User.packages(user) == [package]
   end
 end

--- a/test/hex_web/web/router_test.exs
+++ b/test/hex_web/web/router_test.exs
@@ -4,6 +4,8 @@ defmodule HexWeb.Web.RouterTest do
   alias HexWeb.Router
   alias HexWeb.Package
   alias HexWeb.Release
+  alias HexWeb.User
+  alias HexWeb.PackageOwner
 
   defp release_create(package, version, app, requirements, checksum, inserted_at) do
     {:ok, release} = Release.create(package, rel_meta(%{version: version, app: app, requirements: requirements}), checksum)
@@ -50,5 +52,18 @@ defmodule HexWeb.Web.RouterTest do
     assert conn.assigns[:num_releases] == 6
     assert Enum.count(conn.assigns[:releases_new]) == 6
     assert Enum.count(conn.assigns[:package_new]) == 3
+  end
+
+  test "user page" do
+    {:ok, joe} = User.create(%{username: "joe", email: "joe@example.com", password: "joe"}, true)
+    HexWeb.Repo.insert(%PackageOwner{package_id: Package.get("foo").id, owner_id: joe.id})
+    HexWeb.Repo.insert(%PackageOwner{package_id: Package.get("bar").id, owner_id: joe.id})
+
+    conn = conn(:get, "/users/#{joe.id}")
+    conn = Router.call(conn, [])
+
+    assert conn.status == 200
+    assert conn.assigns[:user].username == "joe"
+    assert Enum.count(conn.assigns[:packages]) == 2
   end
 end


### PR DESCRIPTION
There are many awesome packages in hex.pm.
I would like to know creators who created awesome packages like rubygems.org profile page (e.g. https://rubygems.org/profiles/josevalim). :smiley:
This pull request adds creator specific page that shows user's packages.

## main changes
- user page uri is `/users/:id` for example `/users/100`
- add user page link into `/packages/:name` page

## after this pull request

- package page shows user page links

![2015-08-23 22 35 05](https://cloud.githubusercontent.com/assets/952100/9428431/08ee47b6-49e9-11e5-8f1d-29876ee76fdb.png)

- user page shows user's package

![2015-08-23 22 35 35](https://cloud.githubusercontent.com/assets/952100/9428433/0f9183c6-49e9-11e5-824f-bb53eb9be2fa.png)