### PR TITLE
Add a FAQ page

### DIFF
--- a/lib/hex_web/web/router.ex
+++ b/lib/hex_web/web/router.ex
@@ -95,6 +95,14 @@ defmodule HexWeb.Web.Router do
     send_page(conn, :"docs_codeofconduct")
   end
 
+  get "docs/faq" do
+    active    = :docs
+    title     = "FAQ"
+
+    conn = assign_pun(conn, [active, title])
+    send_page(conn, :"docs_faq")
+  end
+
   get "/packages" do
     active        = :packages
     title         = "Packages"

--- a/lib/hex_web/web/templates.ex
+++ b/lib/hex_web/web/templates.ex
@@ -33,6 +33,7 @@ defmodule HexWeb.Web.Templates do
     docs_publish: [:_],
     docs_tasks: [:_],
     docs_codeofconduct: [:_],
+    docs_faq: [:_],
     reset: [:assigns],
     resetresult: [:assigns],
     versions: [:package, :releases]

--- a/lib/hex_web/web/templates/docs/faq.html.eex
+++ b/lib/hex_web/web/templates/docs/faq.html.eex
@@ -1,0 +1,14 @@
+<h2>FAQ</h2>
+
+<h3>How should I name my packages?</h3>
+
+Please follow these simple rules when choosing the name of the package you're publishing on Hex.
+
+<ol>
+  <li>
+    <b>Never use another package's namespace</b>. For example, the namespace of the plug library is <code>Plug.</code>: if your project extends plug, then its modules should be called <code>PlugExtension</code> instead of <code>Plug.Extension</code>.
+  </li>
+  <li>
+    <b>Prefix extension packages with the original package name</b>. If your package extends the functionality of the plug package, then its name should be something like <code>plug_extension</code>.
+  </li>
+</ol>

--- a/lib/hex_web/web/templates/main.html.eex
+++ b/lib/hex_web/web/templates/main.html.eex
@@ -37,6 +37,7 @@
                 <li><a href="/docs/publish">Publishing packages</a></li>
                 <li><a href="/docs/tasks">Mix tasks</a></li>
                 <li><a href="/docs/codeofconduct">Code of Conduct</a></li>
+                <!-- <li><a href="/docs/faq">FAQ</a></li> -->
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
I added a "FAQ" page under the "Documentation" dropdown as per the discussion in #149.
For now, it only contains guidelines on how to name packages published to Hex; this is the reason why I put it under "Documentation" instead of as its own page (waiting for more content!).

Let me know what you think and if I can do anything else :)