### PR TITLE
"publish" page improvements

### DIFF
--- a/lib/hex_web/web/templates/docs/publish.html.eex
+++ b/lib/hex_web/web/templates/docs/publish.html.eex
@@ -1,7 +1,7 @@
 <h2>Publishing a package</h2>
 
 <p>
-  Publishing a package to Hex consists of registering a Hex user, adding metadata and dependencies to the project's <code>mix.exs</code> file, and finally submitting the package with a <code>mix</code> task.
+  Publishing a package to Hex consists of registering a Hex user, adding metadata to the project's <code>mix.exs</code> file, and finally submitting the package with a <code>mix</code> task.
 </p>
 
 <h3>Registering a Hex user</h3>
@@ -24,13 +24,11 @@ You are required to confirm your email to access your account, a confirmation em
   Once this step has been completed, check your email inbox for the confirmation email. Once you have followed the enclosed link, your account will be ready to use.
 </p>
 
-<h3>Adding metadata and dependencies to <code>mix.exs</code></h3>
+<h3>Adding metadata to <code>mix.exs</code></h3>
 
 <p>
   The package is configured in the <code>project</code> function in the project's <code>mix.exs</code> file. <a href="#example-mix-exs-file">See below</a> for an example file.
 </p>
-
-<h4>Metadata</h4>
 
 <p>
   First, make sure that the <code>:version</code> property is correct. All Hex packages are required to follow <a href="http://semver.org/">semantic versioning</a>. <code>:version</code> and <code>:app</code> (the package name) are the only required properties.

--- a/lib/hex_web/web/templates/docs/publish.html.eex
+++ b/lib/hex_web/web/templates/docs/publish.html.eex
@@ -33,7 +33,7 @@ You are required to confirm your email to access your account, a confirmation em
 <h4>Metadata</h4>
 
 <p>
-First, make sure that the <code>:version</code> property is correct. All Hex packages are required to follow <a href="http://semver.org/">semantic versioning</a>. <code>:version</code> and <code>:app</code> (the package name) are the only required properties.
+  First, make sure that the <code>:version</code> property is correct. All Hex packages are required to follow <a href="http://semver.org/">semantic versioning</a>. <code>:version</code> and <code>:app</code> (the package name) are the only required properties.
 </p>
 
 <p>
@@ -56,6 +56,10 @@ First, make sure that the <code>:version</code> property is correct. All Hex pac
   <dt><code>:build_tools</code></dt>
   <dd>List of build tools that can build the package. Hex will try to automatically detect the build tools, it will do this based on the files in the package. If a "rebar" or "rebar.config" file is present Hex will mark it as able to build with rebar. This detection can be overridden by setting this field.</dd>
 </dl>
+
+<p>
+  These <code>:package</code> properties are also optional but highly recommended.
+</p>
 
 <h4>Dependencies</h4>
 

--- a/lib/hex_web/web/templates/docs/publish.html.eex
+++ b/lib/hex_web/web/templates/docs/publish.html.eex
@@ -45,21 +45,17 @@ You are required to confirm your email to access your account, a confirmation em
 </p>
 
 <dl class="dl-horizontal">
-  <dt><code>:files</code></dt>
-  <dd>A list of files and directories to include in the package. Defaults to standard project directories. Has to include <code>mix.exs</code>.</dd>
   <dt><code>:contributors</code></dt>
-  <dd>A list of names of contributors to the project.</dd>
+  <dd>A list of names of contributors to the project. Optional but highly recommended.</dd>
   <dt><code>:licenses</code></dt>
-  <dd>A list of licences the project is licensed under.</dd>
+  <dd>A list of licences the project is licensed under. Optional but highly recommended.</dd>
   <dt><code>:links</code></dt>
-  <dd>A map where the key is a link name and the value is the link URL.</dd>
+  <dd>A map where the key is a link name and the value is the link URL. Optional but highly recommended.</dd>
+  <dt><code>:files</code></dt>
+  <dd>A list of files and directories to include in the package. Has to include <code>mix.exs</code>. Defaults to standard project directories, so you usually don't need to set this property.</dd>
   <dt><code>:build_tools</code></dt>
-  <dd>List of build tools that can build the package. Hex will try to automatically detect the build tools, it will do this based on the files in the package. If a "rebar" or "rebar.config" file is present Hex will mark it as able to build with rebar. This detection can be overridden by setting this field.</dd>
+  <dd>List of build tools that can build the package. It's very rare that you need to set this, as Hex tries to automatically detect the build tools based on the files in the package. If a "rebar" or "rebar.config" file is present Hex will mark it as able to build with rebar. This detection can be overridden by setting this field.</dd>
 </dl>
-
-<p>
-  These <code>:package</code> properties are also optional but highly recommended.
-</p>
 
 <h4>Dependencies</h4>
 

--- a/lib/hex_web/web/templates/docs/publish.html.eex
+++ b/lib/hex_web/web/templates/docs/publish.html.eex
@@ -1,13 +1,13 @@
 <h2>Publishing a package</h2>
 
 <p>
-  Publishing a package to Hex consists of creating a user, attaching some metadata to the project's <code>mix.exs</code> file and finally performing the command to push.
+  Publishing a package to Hex consists of registering a Hex user, adding metadata and dependencies to the project's <code>mix.exs</code> file, and finally submitting the package with a <code>mix</code> task.
 </p>
 
-<h3>Register a new user</h3>
+<h3>Registering a Hex user</h3>
 
 <p>
-  When registering a user, a username, password, and email will be asked for. The email is used to confirm your identity during signup, as well as to contact you in case there is an issue with one of your packages. The email will never be shared to a third party.
+  When registering a user, you will be prompted for a username, your email and a password. The email is used to confirm your identity during signup, as well as to contact you in case there is an issue with one of your packages. The email will never be shared with a third party.
 </p>
 
 <pre><code>$ mix hex.user register
@@ -24,18 +24,24 @@ You are required to confirm your email to access your account, a confirmation em
   Once this step has been completed, check your email inbox for the confirmation email. Once you have followed the enclosed link, your account will be ready to use.
 </p>
 
-<h3>Adding metadata</h3>
+<h3>Adding metadata and dependencies to <code>mix.exs</code></h3>
 
 <p>
-  The package is configured in Mix's project configuration. First make sure that <code>:version</code> property is correct for the new package version. All Hex packages are required to follow <a href="http://semver.org/">semantic versioning</a>.
+  The package is configured in the <code>project</code> function in the project's <code>mix.exs</code> file. <a href="#example-mix-exs-file">See below</a> for an example file.
+</p>
+
+<h4>Metadata</h4>
+
+<p>
+First, make sure that the <code>:version</code> property is correct. All Hex packages are required to follow <a href="http://semver.org/">semantic versioning</a>. <code>:version</code> and <code>:app</code> (the package name) are the only required properties.
 </p>
 
 <p>
-  Secondly, fill in the <code>:description</code> property. It should be a few sentences describing the package.
+  Then fill in the <code>:description</code> property. It should be a sentence, or a few sentences, describing the package. The <code>:description</code> is optional but highly recommended.
 </p>
 
 <p>
-  Under the <code>:package</code> property are four additional configuration options.
+  Under the <code>:package</code> property are some additional configuration options:
 </p>
 
 <dl class="dl-horizontal">
@@ -44,18 +50,14 @@ You are required to confirm your email to access your account, a confirmation em
   <dt><code>:contributors</code></dt>
   <dd>A list of names of contributors to the project.</dd>
   <dt><code>:licenses</code></dt>
-  <dd>A list of licences the project is licensed with.</dd>
+  <dd>A list of licences the project is licensed under.</dd>
   <dt><code>:links</code></dt>
   <dd>A map where the key is a link name and the value is the link URL.</dd>
   <dt><code>:build_tools</code></dt>
   <dd>List of build tools that can build the package. Hex will try to automatically detect the build tools, it will do this based on the files in the package. If a "rebar" or "rebar.config" file is present Hex will mark it as able to build with rebar. This detection can be overridden by setting this field.</dd>
 </dl>
 
-<p>
-  Only the <code>:version</code> property is required to publish a package. But all other properties are highly recommended to fill in.
-</p>
-
-<h3>Dependencies</h3>
+<h4>Dependencies</h4>
 
 <p>
   A dependency defined with no SCM (<code>:git</code> or <code>:path</code>) will be automatically treated as a Hex dependency. See the <a href="/docs/usage">Usage guide</a> for more details.
@@ -65,38 +67,7 @@ You are required to confirm your email to access your account, a confirmation em
   Only Hex packages will be included as dependencies of the package, for example Git dependencies will not be included. Additionally, only production dependencies will be included, just like how Mix will only fetch production dependencies when fetching the dependencies of your dependencies. Dependencies will be treated as production dependencies when they are defined with no <code>:only</code> property or with <code>only: :prod</code>.
 </p>
 
-<h3>Publishing Elixir packages</h3>
-
-<p>
-  After the package metadata and dependencies have been added to the mixfile we are ready to publish the package. See below for an example of a mixfile.
-</p>
-
-<p>
-  When running the command to publish a package Hex will create a tar file of all the files and directories listed in the <code>:files</code> property. When the tarball has been pushed to the Hex servers, it will be uploaded to a CDN for fast and reliable access for users. Hex will also recompile the registry file that all clients will update automatically when fetching dependencies.
-</p>
-
-<pre><code>$ mix hex.publish
-Publishing postgrex v0.4.0
-  Dependencies:
-    decimal ~> 0.1.0
-  Excluded dependencies (not part of the Hex package):
-    ex_doc
-  Included files:
-    lib/postgrex
-    lib/postgrex/binary_utils.ex
-    lib/postgrex/connection.ex
-    lib/postgrex/protocol.ex
-    lib/postgrex/records.ex
-    lib/postgrex/types.ex
-    mix.exs
-Proceed? [Yn] Y
-Published postgrex v0.4.0
-</code></pre>
-
-<p>
-  Please test your package after publishing by adding it as dependency to a Mix project and fetching and compiling it. If there are any issues you can publish the package again for up to one hour after the first publication. A publication can also be reverted with <code>mix hex.publish --revert VERSION</code>.
-</p>
-
+<a name="example-mix-exs-file"></a>
 <h4>Example mix.exs file</h4>
 
 <pre><code>defmodule Postgrex.Mixfile do
@@ -136,6 +107,42 @@ Published postgrex v0.4.0
   end
 end
 </code></pre>
+
+<h3>Submitting the package</h3>
+
+<p>
+  After the package metadata and dependencies have been added to <code>mix.exs</code>, we are ready to publish the package with the <code>mix hex.publish</code> command:
+</p>
+
+<pre><code>$ mix hex.publish
+Publishing postgrex v0.4.0
+  Dependencies:
+    decimal ~> 0.1.0
+  Excluded dependencies (not part of the Hex package):
+    ex_doc
+  Included files:
+    lib/postgrex
+    lib/postgrex/binary_utils.ex
+    lib/postgrex/connection.ex
+    lib/postgrex/protocol.ex
+    lib/postgrex/records.ex
+    lib/postgrex/types.ex
+    mix.exs
+Proceed? [Yn] Y
+Published postgrex v0.4.0
+</code></pre>
+
+<p>
+  Congratulations, you've published your package! It will appear on the <a href="https://hex.pm/">https://hex.pm</a> site and will be available to add as a dependency in other Mix projects.
+</p>
+
+<p>
+  Please test your package after publishing by adding it as dependency to a Mix project and fetching and compiling it. If there are any issues, you can publish the package again for up to one hour after first publication. A publication can also be reverted with <code>mix hex.publish --revert VERSION</code>.
+</p>
+
+<p>
+  When running the command to publish a package, Hex will create a tar file of all the files and directories listed in the <code>:files</code> property. When the tarball has been pushed to the Hex servers, it will be uploaded to a CDN for fast and reliable access for users. Hex will also recompile the registry file that all clients will update automatically when fetching dependencies.
+</p>
 
 <h3>Publishing Erlang packages</h3>
 


### PR DESCRIPTION
Created my first Hex package yesterday and felt this page could be clearer.

The main improvement is mentioning the example mix.exs file early on in the metadata section, since that's good to reference when reading the description of the properties.

This update also aims to make the overview in the first sentence clearer, and keeping its naming consistent with the headers below.

Also adds some cheer after successfully publishing the package, and moves the technical details below the steps you must follow.