### PR TITLE
Add note about asset caching

### DIFF
--- a/lib/hex_web/email/templates/publish_success.html.eex
+++ b/lib/hex_web/email/templates/publish_success.html.eex
@@ -3,6 +3,10 @@
 </p>
 
 <p>
+  Note that it may take a while for the documentation on hexdocs.pm to update due to caching.
+</p>
+
+<p>
   --<br>
   Hex.pm
 </p>


### PR DESCRIPTION
Assets are served through Cloudflare. Sometimes the assets take awhile
to propagate through the system. This lets user's know that it might
take a bit.

I added "up to an hour" but I'm not actually sure how long it takes. LMK if I should change that to some other value.