### PR TITLE
Dependency config snippet

### DIFF
--- a/lib/hex_web/util.ex
+++ b/lib/hex_web/util.ex
@@ -198,6 +198,16 @@ defmodule HexWeb.Util do
     result.status
   end
 
+  def mix_snippet_version(%Version{major: 0, minor: minor, patch: patch}),
+    do: "~> 0.#{minor}.#{patch}"
+  def mix_snippet_version(%Version{major: major, minor: minor}),
+    do: "~> #{major}.#{minor}"
+
+  def rebar_snippet_version(%Version{major: 0, minor: minor, patch: patch}),
+    do: "0.#{minor}.#{patch}"
+  def rebar_snippet_version(%Version{major: major, minor: minor}),
+    do: "#{major}.#{minor}.*"
+
   def association_loaded?(%Ecto.Association.NotLoaded{}),
     do: false
   def association_loaded?(_),

--- a/lib/hex_web/util.ex
+++ b/lib/hex_web/util.ex
@@ -203,10 +203,8 @@ defmodule HexWeb.Util do
   def mix_snippet_version(%Version{major: major, minor: minor}),
     do: "~> #{major}.#{minor}"
 
-  def rebar_snippet_version(%Version{major: 0, minor: minor, patch: patch}),
-    do: "0.#{minor}.#{patch}"
-  def rebar_snippet_version(%Version{major: major, minor: minor}),
-    do: "#{major}.#{minor}.*"
+  def rebar_snippet_version(%Version{major: major, minor: minor, patch: patch}),
+    do: "#{major}.#{minor}.#{patch}"
 
   def association_loaded?(%Ecto.Association.NotLoaded{}),
     do: false

--- a/lib/hex_web/web/html/helpers.ex
+++ b/lib/hex_web/web/html/helpers.ex
@@ -63,6 +63,29 @@ defmodule HexWeb.Web.HTML.Helpers do
     text
   end
 
+  @doc """
+    A function which formats a packages release info into
+    a build tools dependency snippet
+  """
+  @spec format_dep_snippet(atom, binary, binary, %HexWeb.Release{}) :: binary
+  def format_dep_snippet(build_tool, package_name, snippet, current_release \\ %{meta: %{}})
+
+  def format_dep_snippet(:mix, package_name, snippet, current_release) do
+    app_name = current_release.meta["app"] || package_name
+    case package_name == app_name do
+      true -> "{:#{package_name}, \"#{snippet}\"}"
+      false -> "{:#{app_name}, \"#{snippet}\", hex: :#{package_name}}"
+    end
+  end
+
+  def format_dep_snippet(:rebar, package_name, snippet, current_release) do
+    app_name = current_release.meta["app"] || package_name
+    case package_name == app_name do
+      true -> "{#{package_name}, \"#{snippet}\"}"
+      false -> "{#{app_name}, \"#{snippet}\", {pkg, #{package_name}}}"
+    end
+  end
+
   def human_number_space(string) when is_binary(string) do
     split         = rem(byte_size(string), 3)
     string        = :erlang.binary_to_list(string)

--- a/lib/hex_web/web/router.ex
+++ b/lib/hex_web/web/router.ex
@@ -170,10 +170,12 @@ defmodule HexWeb.Web.Router do
       release_downloads = ReleaseDownload.release(current_release)
       reqs = Release.requirements(current_release)
       current_release = %{current_release | requirements: reqs}
+      mix_snippet = Util.mix_snippet_version(current_release.version)
+      rebar_snippet = Util.rebar_snippet_version(current_release.version)
     end
 
     conn = assign_pun(conn, [package, releases, current_release, downloads,
-                             release_downloads, active, title])
+                             release_downloads, active, title, mix_snippet, rebar_snippet])
     send_page(conn, :package)
   end
 

--- a/lib/hex_web/web/templates/main.html.eex
+++ b/lib/hex_web/web/templates/main.html.eex
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="search" type="application/opensearchdescription+xml" title="Hex" href="/hexsearch.xml">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.1/lumen/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.5/lumen/bootstrap.min.css" rel="stylesheet">
     <link href="/static/main.css?<%= asset_id %>" rel="stylesheet">
     <title><%= if @title, do: "#{@title} | " %>Hex</title>
     <link rel="shortcut icon" href="/favicon.ico">

--- a/lib/hex_web/web/templates/package.html.eex
+++ b/lib/hex_web/web/templates/package.html.eex
@@ -51,12 +51,47 @@ build_tools = @current_release && @current_release.meta["build_tools"] || []
         </dd>
       <% end %>
     </dl>
+    <div style="margin: 10px 0; border-top: 1px solid #eee"></div>
+
+    <div class="row">
+      <div class="col-sm-6">
+        <h4>Versions</h4>
+
+        <ul id="versions" class="list-unstyled">
+          <% show_latest_versions = 5 %>
+          <%= safe template_versions(@package, Enum.take(@releases, show_latest_versions), false) %>
+
+          <%= if length(@releases) > show_latest_versions do %>
+            <%= safe template_versions(@package, Enum.drop(@releases, show_latest_versions), true) %>
+          <% end %>
+        </ul>
+
+        <%= if length(@releases) > show_latest_versions do %>
+          <p class="show-versions"><button class="btn btn-primary toggle-text" role="button" data-toggle="collapse" data-target="#versions li.older" aria-expanded="false" aria-controls="versions">
+            <span>All Versions</span>
+            <span class="invisible">Recent Versions</span>
+          </button></p>
+        <% end %>
+      </div>
+      <div class="col-sm-6">
+        <h4>Dependencies</h4>
+        <ul class="list-unstyled">
+          <%= if @current_release do %>
+            <%= for { name, _app, req, optional } <- @current_release.requirements do %>
+              <li>
+                <a href="/packages/<%= name %>"><strong><%= name %></strong></a>
+                <%= req %>
+                <%= if optional do %>(optional)<% end %>
+              </li>
+            <% end %>
+          <% end %>
+        </ul>
+      </div>
+    </div>
   </div>
   <div class="col-sm-4">
     <div class="panel panel-default">
-      <div class="panel-heading">
-        <h4 class="panel-title">Downloads</h3>
-      </div>
+      <div class="panel-heading"><h4 class="panel-title">Downloads</h4></div>
       <div class="panel-body">
         <table class="downloads">
           <tr>
@@ -78,47 +113,29 @@ build_tools = @current_release && @current_release.meta["build_tools"] || []
         </table>
       </div>
     </div>
-  </div>
-</div>
+    <div class="panel panel-default">
+      <div class="panel-heading"><h4 class="panel-title">Config</h4></div>
+      <div class="panel-body">
+        <div class="package-snippet">
+          mix.exs:
+          <div class="input-group input-group-sm" >
 
-
-<div style="margin: 10px 0; border-top: 1px solid #eee"></div>
-
-<div class="row">
-  <div class="col-sm-6">
-    <h4>Versions</h4>
-
-    <ul id="versions" class="list-unstyled">
-      <% show_latest_versions = 5 %>
-      <%= safe template_versions(@package, Enum.take(@releases, show_latest_versions), false) %>
-
-      <%= if length(@releases) > show_latest_versions do %>
-        <%= safe template_versions(@package, Enum.drop(@releases, show_latest_versions), true) %>
-      <% end %>
-    </ul>
-
-    <%= if length(@releases) > show_latest_versions do %>
-      <p class="show-versions"><button class="btn btn-primary toggle-text" role="button" data-toggle="collapse" data-target="#versions li.older" aria-expanded="false" aria-controls="versions">
-        <span>All Versions</span>
-        <span class="invisible">Recent Versions</span>
-      </button></p>
-    <% end %>
-
-  </div>
-
-  <div class="col-sm-6">
-    <h4>Dependencies</h4>
-
-    <ul class="list-unstyled">
-      <%= if @current_release do %>
-        <%= for { name, _app, req, optional } <- @current_release.requirements do %>
-          <li>
-            <a href="/packages/<%= name %>"><strong><%= name %></strong></a>
-            <%= req %>
-            <%= if optional do %>(optional)<% end %>
-          </li>
-        <% end %>
-      <% end %>
-    </ul>
+            <input type="text" class="form-control snippet"
+              value='{:<%= @package.name %>, "<%= @mix_snippet %>"}'
+              onfocus="this.select();"
+              readonly="readonly" />
+          </div>
+        </div>
+        <div class="package-snippet">
+          rebar.config:
+          <div class="input-group input-group-sm" >
+            <input type="text" class="form-control input-sm snippet"
+              value='{<%= @package.name %>, "<%= @rebar_snippet %>"}'
+              onfocus="this.select();"
+              readonly="readonly" />
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/lib/hex_web/web/templates/package.html.eex
+++ b/lib/hex_web/web/templates/package.html.eex
@@ -121,7 +121,7 @@ build_tools = @current_release && @current_release.meta["build_tools"] || []
           <div class="input-group input-group-sm" >
 
             <input type="text" class="form-control snippet"
-              value='{:<%= @package.name %>, "<%= @mix_snippet %>"}'
+              value="<%= format_dep_snippet(:mix, @package.name, @mix_snippet, @current_release) %>"
               onfocus="this.select();"
               readonly="readonly"  id="mix-snippet" />
             <div class="input-group-btn" >
@@ -135,7 +135,7 @@ build_tools = @current_release && @current_release.meta["build_tools"] || []
           rebar.config:
           <div class="input-group input-group-sm" >
             <input type="text" class="form-control input-sm snippet"
-              value='{<%= @package.name %>, "<%= @rebar_snippet %>"}'
+              value="<%= format_dep_snippet(:rebar, @package.name, @rebar_snippet, @current_release) %>"
               onfocus="this.select();"
               readonly="readonly"  id="rebar-snippet" />
             <div class="input-group-btn" >

--- a/lib/hex_web/web/templates/package.html.eex
+++ b/lib/hex_web/web/templates/package.html.eex
@@ -123,7 +123,12 @@ build_tools = @current_release && @current_release.meta["build_tools"] || []
             <input type="text" class="form-control snippet"
               value='{:<%= @package.name %>, "<%= @mix_snippet %>"}'
               onfocus="this.select();"
-              readonly="readonly" />
+              readonly="readonly"  id="mix-snippet" />
+            <div class="input-group-btn" >
+              <button class="btn btn-default" type="button" onclick="copy_snippet('mix-snippet', this);">
+                <span class="glyphicon glyphicon-copy" ></span>
+              </button>
+            </div>
           </div>
         </div>
         <div class="package-snippet">
@@ -132,7 +137,12 @@ build_tools = @current_release && @current_release.meta["build_tools"] || []
             <input type="text" class="form-control input-sm snippet"
               value='{<%= @package.name %>, "<%= @rebar_snippet %>"}'
               onfocus="this.select();"
-              readonly="readonly" />
+              readonly="readonly"  id="rebar-snippet" />
+            <div class="input-group-btn" >
+              <button class="btn btn-default" type="button"  onclick="copy_snippet('rebar-snippet', this);">
+                <span class="glyphicon glyphicon-copy" ></span>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/priv/static/static/main.css
+++ b/priv/static/static/main.css
@@ -151,3 +151,7 @@ body {
 .package-snippet {
   margin: 0px 0px 10px;
 }
+
+.green {
+  color: green;
+}

--- a/priv/static/static/main.css
+++ b/priv/static/static/main.css
@@ -155,3 +155,7 @@ body {
 .green {
   color: green;
 }
+
+.input-group {
+  display: inline-table;
+}

--- a/priv/static/static/main.css
+++ b/priv/static/static/main.css
@@ -142,3 +142,12 @@ body {
   font-size: 14px;
   color: #333;
 }
+
+.snippet, .snippet[readonly] {
+  cursor: default;
+  background-color: transparent;
+}
+
+.package-snippet {
+  margin: 0px 0px 10px;
+}

--- a/priv/static/static/main.js
+++ b/priv/static/static/main.js
@@ -10,3 +10,26 @@ $('.show-versions .toggle-text').click(function() {
   $(this).find('span').toggle();
 });
 
+// Package: copy config snippet to clipboard
+function copy_snippet(element_id, button) {
+  try {
+    snippet = document.getElementById(element_id);
+    snippet.select();
+
+    if( document.execCommand('copy') ) { copy_succeeded(button); }
+    else { copy_failed(button); }
+  } catch (e) {
+    console.log('snippet copy failed', e);
+    copy_failed(button);
+  }
+}
+
+function copy_succeeded(button) {
+  $(button).children().removeClass("glyphicon-copy").addClass("glyphicon-ok green");
+  setTimeout(function() { $(button).children().removeClass("glyphicon-ok green").addClass("glyphicon-copy") }, 1500);
+}
+
+function copy_failed(button) {
+  $(button).children().removeClass("glyphicon-copy").addClass("glyphicon-remove");
+  setTimeout(function() { $(button).children().removeClass("glyphicon-remove").addClass("glyphicon-copy") }, 1500);
+}

--- a/priv/static/static/main.js
+++ b/priv/static/static/main.js
@@ -12,24 +12,28 @@ $('.show-versions .toggle-text').click(function() {
 
 // Package: copy config snippet to clipboard
 function copy_snippet(element_id, button) {
+  succeeded = false;
   try {
     snippet = document.getElementById(element_id);
     snippet.select();
 
-    if( document.execCommand('copy') ) { copy_succeeded(button); }
-    else { copy_failed(button); }
+    succeeded = document.execCommand('copy')
   } catch (e) {
     console.log('snippet copy failed', e);
-    copy_failed(button);
   }
+
+  if(succeeded) { copy_succeeded(button) }
+  else { copy_failed(button); }
 }
 
 function copy_succeeded(button) {
   $(button).children().removeClass("glyphicon-copy").addClass("glyphicon-ok green");
-  setTimeout(function() { $(button).children().removeClass("glyphicon-ok green").addClass("glyphicon-copy") }, 1500);
+  $(button).tooltip({ title: 'Copied!', container: 'body', placement: 'bottom', trigger: 'manual' }).tooltip('show');
+  setTimeout(function() { $(button).children().removeClass("glyphicon-ok green").addClass("glyphicon-copy"); $(button).tooltip("hide")  }, 1500);
 }
 
 function copy_failed(button) {
   $(button).children().removeClass("glyphicon-copy").addClass("glyphicon-remove");
-  setTimeout(function() { $(button).children().removeClass("glyphicon-remove").addClass("glyphicon-copy") }, 1500);
+  $(button).tooltip({ title: 'Copy failed :(', container: 'body', placement: 'bottom', trigger: 'manual' }).tooltip('show');
+  setTimeout(function() { $(button).children().removeClass("glyphicon-remove").addClass("glyphicon-copy"); $(button).tooltip("hide")  }, 1500);
 }

--- a/test/hex_web/util_test.exs
+++ b/test/hex_web/util_test.exs
@@ -9,4 +9,24 @@ defmodule HexWeb.UtilTest do
     input = "WSDL/SOAP*()"
     assert Util.safe_search(input) == "WSDL SOAP"
   end
+
+  test "mix config snippet" do
+    alpha_version   = %Version{major: 0, minor: 0, patch: 2}
+    beta_version    = %Version{major: 0, minor: 2, patch: 99}
+    stable_version  = %Version{major: 2, minor: 0, patch: 2}
+
+    assert Util.mix_snippet_version(alpha_version)  == "~> 0.0.2"
+    assert Util.mix_snippet_version(beta_version)   == "~> 0.2.99"
+    assert Util.mix_snippet_version(stable_version) == "~> 2.0"
+  end
+
+  test "rebar config snippet" do
+    alpha_version   = %Version{major: 0, minor: 0, patch: 2}
+    beta_version    = %Version{major: 0, minor: 2, patch: 99}
+    stable_version  = %Version{major: 2, minor: 0, patch: 2}
+
+    assert Util.rebar_snippet_version(alpha_version)  == "0.0.2"
+    assert Util.rebar_snippet_version(beta_version)   == "0.2.99"
+    assert Util.rebar_snippet_version(stable_version) == "2.0.2"
+  end
 end

--- a/test/hex_web/web/html/helpers_test.exs
+++ b/test/hex_web/web/html/helpers_test.exs
@@ -1,0 +1,29 @@
+defmodule HexWeb.Web.HTML.HelpersTest do
+  use HexWebTest.Case
+
+  alias HexWeb.Web.HTML.Helpers
+
+  test "format simple mix dependency snippet" do
+    package_name = "ecto"
+    release = %{meta: %{"app" => package_name}}
+    assert Helpers.format_dep_snippet(:mix, package_name, "~> 1.0", release) == "{:ecto, \"~> 1.0\"}"
+  end
+
+  test "format mix dependency snippet" do
+    package_name = "timex"
+    release = %{ meta: %{ "app" => "extime"}}
+    assert Helpers.format_dep_snippet(:mix, package_name, "~> 1.0", release) == "{:extime, \"~> 1.0\", hex: :timex}"
+  end
+
+  test "format simple rebar dependency snippet" do
+    package_name = "rebar"
+    release = %{meta: %{"app" => package_name}}
+    assert Helpers.format_dep_snippet(:rebar, package_name, "1.0.0", release) == "{rebar, \"1.0.0\"}"
+  end
+
+  test "format rebar dependency snippet" do
+    package_name = "rebar"
+    release = %{ meta: %{ "app" => "erlang_mk"}}
+    assert Helpers.format_dep_snippet(:rebar, package_name, "1.0.1", release) == "{erlang_mk, \"1.0.1\", {pkg, rebar}}"
+  end
+end


### PR DESCRIPTION
Fixes #110 :

- add snippet for mix & rebar config
- upgraded bootswatch version (so I could use glyphicons)
- added copy button (works in Chrome, FF < 41, Safari don't support it, untested in IE etc)

~~There was no tooltip lib, since it didn't want to introduce new deps I made a crude 'copy' animation~~ Tooltip added
