### PR TITLE
Enable syntax highlighting for doc code blocks

### DIFF
--- a/lib/hex_web/web/templates/docs/publish.html.eex
+++ b/lib/hex_web/web/templates/docs/publish.html.eex
@@ -10,7 +10,7 @@
   When registering a user, you will be prompted for a username, your email and a password. The email is used to confirm your identity during signup, as well as to contact you in case there is an issue with one of your packages. The email will never be shared with a third party.
 </p>
 
-<pre><code>$ mix hex.user register
+<pre><code class="nohighlight">$ mix hex.user register
 Username: johndoe
 Email: john.doe@example.com
 Password:
@@ -68,7 +68,7 @@ You are required to confirm your email to access your account, a confirmation em
 <a name="example-mix-exs-file"></a>
 <h4>Example mix.exs file</h4>
 
-<pre><code>defmodule Postgrex.Mixfile do
+<pre><code class="elixir">defmodule Postgrex.Mixfile do
   use Mix.Project
 
   def project do
@@ -112,7 +112,7 @@ end
   After the package metadata and dependencies have been added to <code>mix.exs</code>, we are ready to publish the package with the <code>mix hex.publish</code> command:
 </p>
 
-<pre><code>$ mix hex.publish
+<pre><code class="nohighlight">$ mix hex.publish
 Publishing postgrex v0.4.0
   Dependencies:
     decimal ~> 0.1.0

--- a/lib/hex_web/web/templates/docs/rebar3/publish.html.eex
+++ b/lib/hex_web/web/templates/docs/rebar3/publish.html.eex
@@ -5,7 +5,7 @@
 
 <h4>Example rebar.config file</h4>
 
-<pre><code>{plugins, [rebar3_hex]}.</code></pre>
+<pre><code class="erlang">{plugins, [rebar3_hex]}.</code></pre>
 
 <p>
   Publishing a package to Hex consists of registering a Hex user, adding metadata to the project's <code>.app.src</code> file, and finally submitting the package with a <code>rebar3</code> provider.
@@ -17,7 +17,7 @@
   When registering a user, you will be prompted for a username, your email and a password. The email is used to confirm your identity during signup, as well as to contact you in case there is an issue with one of your packages. The email will never be shared with a third party.
 </p>
 
-<pre><code>$ rebar3 hex user register
+<pre><code class="nohighlight">$ rebar3 hex user register
 Username: johndoe
 Email: john.doe@example.com
 Password:
@@ -75,7 +75,7 @@ You are required to confirm your email to access your account, a confirmation em
 <a name="example-rebar-config-file"></a>
 <h4>Example rebar.config file</h4>
 
-<pre><code>{deps, [{erlware_commons, "0.15.0"},
+<pre><code class="erlang">{deps, [{erlware_commons, "0.15.0"},
         {providers, "1.4.1"},
         {getopt, "0.8.2"},
         {bbmustache, "1.0.3"}
@@ -85,7 +85,7 @@ You are required to confirm your email to access your account, a confirmation em
 <a name="example-app-src-file"></a>
 <h4>Example .app.src file</h4>
 
-<pre><code>{application, relx,
+<pre><code class="erlang">{application, relx,
   [{description, "Release assembler for Erlang/OTP Releases"},
    {vsn, "3.5.0"},
    {modules, []},
@@ -108,7 +108,7 @@ You are required to confirm your email to access your account, a confirmation em
   After the package metadata and dependencies have been added to <code>.app.src</code>, we are ready to publish the package with the <code>rebar3 hex publish</code> command:
 </p>
 
-<pre><code>$ rebar3 hex publish
+<pre><code class="nohighlight">$ rebar3 hex publish
 Publishing relx 3.5.0
   Dependencies:
     bbmustache 1.0.3

--- a/lib/hex_web/web/templates/docs/rebar3/usage.html.eex
+++ b/lib/hex_web/web/templates/docs/rebar3/usage.html.eex
@@ -10,7 +10,7 @@
   Hex packages as dependencies are supported by rebar3 even without the plugin. The hex plugin is only required for publishing an application as a hex package.
 </p>
 
-<pre><code>{deps,[
+<pre><code class="erlang">{deps,[
   ranch,                  %% picks the highest available version
   {cowboy,"1.0.1"},       %% sets the version to use
   {uuid, {pkg, uuid_erl}} %% app under a different pkg name

--- a/lib/hex_web/web/templates/docs/tasks.html.eex
+++ b/lib/hex_web/web/templates/docs/tasks.html.eex
@@ -288,4 +288,3 @@ hex config.</p>
 
     </div>
   </div>
-

--- a/lib/hex_web/web/templates/docs/usage.html.eex
+++ b/lib/hex_web/web/templates/docs/usage.html.eex
@@ -22,7 +22,7 @@
   The version requirement specify which versions of the package you allow. The formats accepted for the requirement are documented in the <a href="http://elixir-lang.org/docs/stable/elixir/Version.html">Version module</a>. Below is an example <code>mix.exs</code> file.
 </p>
 
-<pre><code>defmodule MyProject.Mixfile do
+<pre><code class="elixir">defmodule MyProject.Mixfile do
   use Mix.Project
 
   def project do

--- a/lib/hex_web/web/templates/main.html.eex
+++ b/lib/hex_web/web/templates/main.html.eex
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="search" type="application/opensearchdescription+xml" title="Hex" href="/hexsearch.xml">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.5/lumen/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.8.0/styles/github.min.css">
     <link href="/static/main.css?<%= asset_id %>" rel="stylesheet">
     <title><%= if @title, do: "#{@title} | " %>Hex</title>
     <link rel="shortcut icon" href="/favicon.ico">
@@ -81,6 +82,7 @@
 
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/js/bootstrap.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.8.0/highlight.min.js"></script>
     <script src="/static/main.js?<%= asset_id %>"></script>
 
     <script>

--- a/priv/static/static/main.css
+++ b/priv/static/static/main.css
@@ -29,6 +29,10 @@ body {
   margin-bottom: 60px;
 }
 
+pre {
+  background-color: #f8f8f8;
+}
+
 #footer {
   position: absolute;
   bottom: 0;

--- a/priv/static/static/main.js
+++ b/priv/static/static/main.js
@@ -10,6 +10,9 @@ $('.show-versions .toggle-text').click(function() {
   $(this).find('span').toggle();
 });
 
+// Highlight syntax
+hljs.initHighlightingOnLoad();
+
 // Package: copy config snippet to clipboard
 function copy_snippet(element_id, button) {
   succeeded = false;


### PR DESCRIPTION
This PR uses [highlight.js](https://highlightjs.org) to highlight the Elixir and Erlang syntax in the documentation.