### PR TITLE
Improved development documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ To contribute to HexWeb you need to properly set up your development environment
 
 Also see the client repository: [hex](https://github.com/hexpm/hex). The client uses `hex_web` for integration tests, so `hex_web` needs to support all versions the client supports. Travis tests ensures that tests are run on all supported versions.
 
-### PostgreSQL Modules
+### PostgreSQL Modules And Version
 
-HexWeb requires the PostgreSQL modules [pg_trgm](http://www.postgresql.org/docs/9.3/static/pgtrgm.html) and [pgcrypto](http://www.postgresql.org/docs/9.3/static/pgcrypto.html) to be available.
+PostgreSQL version should be >= 9.4, as HexWeb uses the `jsonb` type, that is available from PostgreSQL 9.4 onward.
+
+HexWeb requires the PostgreSQL modules [pg_trgm](http://www.postgresql.org/docs/9.4/static/pgtrgm.html) and [pgcrypto](http://www.postgresql.org/docs/9.4/static/pgcrypto.html) to be available.
 
 This is located in the "postgresql-contrib" package, however the package name can vary depending on your operating system. If the module is not installed the ecto migrations will fail.
 


### PR DESCRIPTION
Has stated [here](http://www.postgresql.org/docs/9.4/static/release-9-4.html), `jsonb` has been introduced in version `9.4`, but the links were pointing the `9.3` documentation. Also I explicitly added in the documentation that the version should be at least 9.4. Hope it helps.