### PR TITLE
[WIP #162] Reject package pushes with no description

### DIFF
--- a/lib/hex_web/package.ex
+++ b/lib/hex_web/package.ex
@@ -58,7 +58,7 @@ defmodule HexWeb.Package do
     validate_change(changeset, field, fn _field, meta ->
       errors =
         Enum.flat_map(@meta_fields_required, fn field ->
-          if Map.has_key?(meta, field) do
+          if Map.has_key?(meta, field) and is_present(meta[field]) do
             []
           else
             [{field, :missing}]
@@ -70,6 +70,12 @@ defmodule HexWeb.Package do
         else: [{field, errors}]
     end)
   end
+
+  defp is_present(string) when is_binary(string) do
+    (string |> String.strip |> String.length) > 0
+  end
+
+  defp is_present(string), do: true
 
   defp changeset(package, :create, params) do
     changeset(package, :update, params)

--- a/lib/hex_web/package.ex
+++ b/lib/hex_web/package.ex
@@ -37,6 +37,7 @@ defmodule HexWeb.Package do
   }
 
   @meta_fields Map.keys(@meta_types)
+  @meta_fields_required ~w(description)
 
   before_delete :delete_owners
 
@@ -53,9 +54,27 @@ defmodule HexWeb.Package do
     end)
   end
 
+  defp validate_required_meta(changeset, field) do
+    validate_change(changeset, field, fn _field, meta ->
+      errors =
+        Enum.flat_map(@meta_fields_required, fn field ->
+          if Map.has_key?(meta, field) do
+            []
+          else
+            [{field, :missing}]
+          end
+        end)
+
+      if errors == [],
+          do: [],
+        else: [{field, errors}]
+    end)
+  end
+
   defp changeset(package, :create, params) do
     changeset(package, :update, params)
     |> validate_unique(:name, on: HexWeb.Repo)
+    |> validate_required_meta(:meta)
   end
 
   # TODO: Drop support for contributors (maintainers released in 0.9.0, date TBD)

--- a/test/hex_web/api/router_test.exs
+++ b/test/hex_web/api/router_test.exs
@@ -50,7 +50,7 @@ defmodule HexWeb.API.RouterTest do
     assert contents =~ "confirm?username=name&key=" <> user.confirmation_key
 
     {:ok, key} = Key.create(user, %{name: "macbook"})
-    body = %{meta: %{ description: "Domain-specific language." }}
+    body = %{meta: %{description: "Domain-specific language."}}
     conn = conn("PUT", "/api/packages/ecto", Poison.encode!(body))
            |> put_req_header("content-type", "application/json")
            |> put_req_header("authorization", key.user_secret)
@@ -91,7 +91,7 @@ defmodule HexWeb.API.RouterTest do
     user = User.get(username: "eric")
     {:ok, key} = Key.create(user, %{name: "macbook"})
 
-    body = %{meta: %{ description: "Domain-specific language." }}
+    body = %{meta: %{description: "Domain-specific language."}}
     conn = conn("PUT", "/api/packages/ecto", Poison.encode!(body))
            |> put_req_header("content-type", "application/json")
            |> put_req_header("authorization", key.user_secret)
@@ -101,7 +101,7 @@ defmodule HexWeb.API.RouterTest do
   end
 
   test "create package key auth" do
-    body = %{meta: %{ description: "Domain-specific language." }}
+    body = %{meta: %{description: "Domain-specific language."}}
     conn = conn("PUT", "/api/packages/ecto", Poison.encode!(body))
            |> put_req_header("content-type", "application/json")
            |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))

--- a/test/hex_web/api/router_test.exs
+++ b/test/hex_web/api/router_test.exs
@@ -15,8 +15,8 @@ defmodule HexWeb.API.RouterTest do
     User.create(%{username: "other", email: "other@mail.com", password: "other"}, true)
     User.create(%{username: "jose", email: "jose@mail.com", password: "jose"}, true)
     {:ok, user} = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
-    {:ok, _}    = Package.create(user, pkg_meta(%{name: "postgrex"}))
-    {:ok, pkg}  = Package.create(user, pkg_meta(%{name: "decimal"}))
+    {:ok, _}    = Package.create(user, pkg_meta(%{name: "postgrex", description: "Postgrex is awesome"}))
+    {:ok, pkg}  = Package.create(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal arithmetic for Elixir."}))
     {:ok, rel}  = Release.create(pkg, rel_meta(%{version: "0.0.1", app: "decimal", requirements: %{postgrex: "0.0.1"}}), "")
 
     %{rel | has_docs: true} |> HexWeb.Repo.update
@@ -50,7 +50,7 @@ defmodule HexWeb.API.RouterTest do
     assert contents =~ "confirm?username=name&key=" <> user.confirmation_key
 
     {:ok, key} = Key.create(user, %{name: "macbook"})
-    body = %{meta: %{}}
+    body = %{meta: %{ description: "Domain-specific language." }}
     conn = conn("PUT", "/api/packages/ecto", Poison.encode!(body))
            |> put_req_header("content-type", "application/json")
            |> put_req_header("authorization", key.user_secret)
@@ -91,7 +91,7 @@ defmodule HexWeb.API.RouterTest do
     user = User.get(username: "eric")
     {:ok, key} = Key.create(user, %{name: "macbook"})
 
-    body = %{meta: %{}}
+    body = %{meta: %{ description: "Domain-specific language." }}
     conn = conn("PUT", "/api/packages/ecto", Poison.encode!(body))
            |> put_req_header("content-type", "application/json")
            |> put_req_header("authorization", key.user_secret)
@@ -101,7 +101,7 @@ defmodule HexWeb.API.RouterTest do
   end
 
   test "create package key auth" do
-    body = %{meta: %{}}
+    body = %{meta: %{ description: "Domain-specific language." }}
     conn = conn("PUT", "/api/packages/ecto", Poison.encode!(body))
            |> put_req_header("content-type", "application/json")
            |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
@@ -118,7 +118,7 @@ defmodule HexWeb.API.RouterTest do
   end
 
   test "update package" do
-    Package.create(User.get(username: "eric"), pkg_meta(%{name: "ecto"}))
+    Package.create(User.get(username: "eric"), pkg_meta(%{name: "ecto", description: "DSL"}))
 
     body = %{meta: %{description: "awesomeness"}}
     conn = conn("PUT", "/api/packages/ecto", Poison.encode!(body))
@@ -145,7 +145,7 @@ defmodule HexWeb.API.RouterTest do
   end
 
   test "update package authorizes" do
-    Package.create(User.get(username: "eric"), pkg_meta(%{name: "ecto"}))
+    Package.create(User.get(username: "eric"), pkg_meta(%{name: "ecto", description: "DSL"}))
 
     body = %{}
     conn = conn("PUT", "/api/packages/ecto", Poison.encode!(body))
@@ -202,7 +202,7 @@ defmodule HexWeb.API.RouterTest do
   test "create release also creates package" do
     refute Package.get("phoenix")
 
-    body = create_tar(%{name: :phoenix, app: "phoenix", version: "1.0.0"}, [])
+    body = create_tar(%{name: :phoenix, app: "phoenix", description: "Web framework", version: "1.0.0"}, [])
     conn = conn("POST", "/api/packages/phoenix/releases", body)
            |> put_req_header("content-type", "application/json")
            |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
@@ -689,7 +689,7 @@ defmodule HexWeb.API.RouterTest do
     :inets.start
 
     user           = User.get(username: "eric")
-    {:ok, phoenix} = Package.create(user, pkg_meta(%{name: "phoenix"}))
+    {:ok, phoenix} = Package.create(user, pkg_meta(%{name: "phoenix", description: "Web framework"}))
     {:ok, _}       = Release.create(phoenix, rel_meta(%{version: "0.0.1", app: "phoenix"}), "")
     {:ok, _}       = Release.create(phoenix, rel_meta(%{version: "0.0.2", app: "phoenix"}), "")
 
@@ -747,7 +747,7 @@ defmodule HexWeb.API.RouterTest do
     :inets.start
 
     user        = User.get(username: "eric")
-    {:ok, ecto} = Package.create(user, pkg_meta(%{name: "ecto"}))
+    {:ok, ecto} = Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"}))
     {:ok, _}    = Release.create(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "")
 
     path = Path.join("tmp", "release-docs.tar.gz")
@@ -792,7 +792,7 @@ defmodule HexWeb.API.RouterTest do
     :inets.start
 
     user        = User.get(username: "eric")
-    {:ok, ecto} = Package.create(user, pkg_meta(%{name: "ecto"}))
+    {:ok, ecto} = Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"}))
     {:ok, _}    = Release.create(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "")
 
     path = Path.join("tmp", "release-docs.tar.gz")

--- a/test/hex_web/package_test.exs
+++ b/test/hex_web/package_test.exs
@@ -66,6 +66,20 @@ defmodule HexWeb.PackageTest do
     assert length(errors[:meta]) == 4
   end
 
+  test "validate blank description in metadata" do
+    meta = %{
+      "maintainers" => ["eric", "josé"],
+      "licenses"     => ["apache", "BSD"],
+      "links"        => %{"github" => "www", "docs" => "www"},
+      "description"  => ""}
+
+    user = User.get(username: "eric")
+    assert {:error, errors} = Package.create(user, pkg_meta(%{name: "ecto", meta: meta}))
+    assert length(errors) == 1
+    assert length(errors[:meta]) == 1
+    assert errors[:meta] == [{"description", :missing}]
+  end
+
   test "packages are unique" do
     user = User.get(username: "eric")
     assert {:ok, %Package{}} = Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"}))

--- a/test/hex_web/package_test.exs
+++ b/test/hex_web/package_test.exs
@@ -12,14 +12,14 @@ defmodule HexWeb.PackageTest do
   test "create package and get" do
     user = User.get(username: "eric")
     user_id = user.id
-    assert {:ok, %Package{}} = Package.create(user, pkg_meta(%{name: "ecto"}))
+    assert {:ok, %Package{}} = Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"}))
     assert [%User{id: ^user_id}] = Package.get("ecto") |> Package.owners
     assert is_nil(Package.get("postgrex"))
   end
 
   test "update package" do
     user = User.get(username: "eric")
-    assert {:ok, package} = Package.create(user, pkg_meta(%{name: "ecto"}))
+    assert {:ok, package} = Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"}))
 
     Package.update(package, %{"meta" => %{"contributors" => ["eric", "josé"]}})
     package = Package.get("ecto")
@@ -41,13 +41,15 @@ defmodule HexWeb.PackageTest do
   test "ignore unknown meta fields" do
     meta = %{
       "contributors" => ["eric"],
-      "foo"          => "bar"}
+      "foo"          => "bar",
+      "description" => "Lorem ipsum"
+    }
 
     user = User.get(username: "eric")
     assert {:ok, %Package{}} = Package.create(user, pkg_meta(%{name: "ecto", meta: meta}))
     assert %Package{meta: meta2} = Package.get("ecto")
 
-    assert Map.size(meta2) == 1
+    assert Map.size(meta2) == 2
     assert meta["contributors"] == meta2["maintainers"]
   end
 
@@ -66,12 +68,12 @@ defmodule HexWeb.PackageTest do
 
   test "packages are unique" do
     user = User.get(username: "eric")
-    assert {:ok, %Package{}} = Package.create(user, pkg_meta(%{name: "ecto"}))
-    assert {:error, _} = Package.create(user, pkg_meta(%{name: "ecto"}))
+    assert {:ok, %Package{}} = Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"}))
+    assert {:error, _} = Package.create(user, pkg_meta(%{name: "ecto", description: "Domain-specific language"}))
   end
 
   test "reserved names" do
     user = User.get(username: "eric")
-    assert {:error, [name: "is reserved"]} = Package.create(user, pkg_meta(%{name: "elixir"}))
+    assert {:error, [name: "is reserved"]} = Package.create(user, pkg_meta(%{name: "elixir", description: "Awesomeness."}))
   end
 end

--- a/test/hex_web/registry_builder_test.exs
+++ b/test/hex_web/registry_builder_test.exs
@@ -11,9 +11,9 @@ defmodule HexWeb.RegistryBuilderTest do
 
   setup do
     {:ok, user} = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
-    {:ok, _} = Package.create(user, pkg_meta(%{name: "postgrex"}))
-    {:ok, _} = Package.create(user, pkg_meta(%{name: "decimal"}))
-    {:ok, _} = Package.create(user, pkg_meta(%{name: "ex_doc"}))
+    {:ok, _} = Package.create(user, pkg_meta(%{name: "postgrex", description: "PostgreSQL driver for Elixir."}))
+    {:ok, _} = Package.create(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal arithmetic for Elixir."}))
+    {:ok, _} = Package.create(user, pkg_meta(%{name: "ex_doc", description: "ExDoc"}))
     {:ok, _} = Install.create("0.0.1", ["0.13.0-dev"])
     {:ok, _} = Install.create("0.1.0", ["0.13.1-dev", "0.13.1"])
     :ok

--- a/test/hex_web/release_test.exs
+++ b/test/hex_web/release_test.exs
@@ -7,9 +7,9 @@ defmodule HexWeb.ReleaseTest do
 
   setup do
     {:ok, user} = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
-    {:ok, _} = Package.create(user, pkg_meta(%{name: "ecto"}))
-    {:ok, _} = Package.create(user, pkg_meta(%{name: "postgrex"}))
-    {:ok, _} = Package.create(user, pkg_meta(%{name: "decimal"}))
+    {:ok, _} = Package.create(user, pkg_meta(%{name: "ecto", description: "Ecto is awesome"}))
+    {:ok, _} = Package.create(user, pkg_meta(%{name: "postgrex", description: "Postgrex is awesome"}))
+    {:ok, _} = Package.create(user, pkg_meta(%{name: "decimal", description: "Decimal is awesome, too"}))
     :ok
   end
 

--- a/test/hex_web/router_test.exs
+++ b/test/hex_web/router_test.exs
@@ -10,8 +10,8 @@ defmodule HexWeb.RouterTest do
 
   setup do
     {:ok, user} = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
-    {:ok, _}    = Package.create(user, pkg_meta(%{name: "postgrex"}))
-    {:ok, pkg}  = Package.create(user, pkg_meta(%{name: "decimal"}))
+    {:ok, _}    = Package.create(user, pkg_meta(%{name: "postgrex", description: "PostgreSQL driver for Elixir."}))
+    {:ok, pkg}  = Package.create(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal arithmetic for Elixir."}))
     {:ok, _}    = Release.create(pkg, rel_meta(%{version: "0.0.1", app: "decimal", requirements: %{postgrex: "0.0.1"}}), "")
     :ok
   end

--- a/test/hex_web/stats/job_test.exs
+++ b/test/hex_web/stats/job_test.exs
@@ -9,9 +9,9 @@ defmodule HexWeb.Stats.JobTest do
 
   setup do
     {:ok, user} = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
-    {:ok, foo} = Package.create(user, pkg_meta(%{name: "foo"}))
-    {:ok, bar} = Package.create(user, pkg_meta(%{name: "bar"}))
-    {:ok, other} = Package.create(user, pkg_meta(%{name: "other"}))
+    {:ok, foo} = Package.create(user, pkg_meta(%{name: "foo", description: "Foo"}))
+    {:ok, bar} = Package.create(user, pkg_meta(%{name: "bar", description: "Bar"}))
+    {:ok, other} = Package.create(user, pkg_meta(%{name: "other", description: "Other"}))
 
     {:ok, _} = Release.create(foo, rel_meta(%{version: "0.0.1", app: "foo"}), "")
     {:ok, _} = Release.create(foo, rel_meta(%{version: "0.0.2", app: "foo"}), "")


### PR DESCRIPTION
Taking a stab at https://github.com/hexpm/hex_web/issues/162 
(It's my first PR here, so if I'm breaking any coding standards I will be more than happy to fix)

The implementation basically mimics how ```release.ex``` does the validation of the meta data. 

Also, per the discussion on #162, it's been mentioned about updating the client. Could anyone point me in the right direction there? Thanks!