### PR TITLE
Fix displaing data on small screens

### DIFF
--- a/priv/static/static/main.css
+++ b/priv/static/static/main.css
@@ -62,6 +62,7 @@ pre {
 
 .packages {
   table-layout: fixed;
+  min-width: 420px;
 }
 
 .packages td {


### PR DESCRIPTION
On small screens (namely phones) list of packages looks weird and unusable.

Examples, Galaxy Note 3, Opera (engine: webkit), Fennec (== firefox)
![screenshot_2015-10-25-04-01-14](https://cloud.githubusercontent.com/assets/736279/10713546/0af26644-7ace-11e5-8cb7-84affcbfa0a8.png)
![screenshot_2015-10-25-04-07-02](https://cloud.githubusercontent.com/assets/736279/10713547/0b119dfc-7ace-11e5-9167-41eb8dea878c.png)

This patch sets minimum bar how narrow table could be. If it doesn't fit in screen, some horizontal scrolling will be added