### PR TITLE
API: sort packages predictably

### DIFF
--- a/lib/hex_web/package.ex
+++ b/lib/hex_web/package.ex
@@ -244,17 +244,17 @@ defmodule HexWeb.Package do
   end
 
   defp sort(query, :inserted_at) do
-    from d in query, order_by: [desc: :inserted_at]
+    from d in query, order_by: [desc: :inserted_at, desc: :id]
   end
 
   defp sort(query, :updated_at) do
-    from d in query, order_by: [desc: :updated_at]
+    from d in query, order_by: [desc: :updated_at, desc: :id]
   end
 
   defp sort(query, :downloads) do
     from p in query,
     left_join: d in HexWeb.Stats.PackageDownload, on: p.id == d.package_id and d.view == "all",
-    order_by: [asc: is_nil(d.downloads), desc: d.downloads]
+    order_by: [asc: is_nil(d.downloads), desc: d.downloads, desc: p.id]
   end
 
   defp sort(query, nil) do


### PR DESCRIPTION
E.g. two packages updated at the exact same time should predictably appear in
the same order. Postgres makes no such guarantees if you don't sort
by some unique column as well: http://stackoverflow.com/questions/11263715/is-postgresql-order-fully-guaranteed-if-sorting-on-a-non-unique-attribute

I thought I would need this for an integration but turns out I didn't. So I don't have a specific use case for it, but it seems like an improvement to me.

I could not find a test that covered this in any detail, so I didn't add any.

What do you think?