### PR TITLE
Add unversioned hexdocs link to package view

### DIFF
--- a/lib/hex_web/util.ex
+++ b/lib/hex_web/util.ex
@@ -141,6 +141,14 @@ defmodule HexWeb.Util do
   end
 
   @doc """
+  Returns a url to the documentation tarball in the Amazon S3 Hex.pm bucket.
+  """
+  @spec docs_tarball_url(String.t) :: String.t
+  def docs_tarball_url(package_name) do
+    Application.get_env(:hex_web, :s3_url) <> "/" <> Application.get_env(:hex_web, :s3_bucket) <> "/docs/#{package_name}.tar.gz"
+  end
+
+  @doc """
   Converts an ecto datetime record to ISO 8601 format.
   """
   @spec to_iso8601(Ecto.DateTime.t) :: String.t

--- a/lib/hex_web/web/router.ex
+++ b/lib/hex_web/web/router.ex
@@ -176,6 +176,14 @@ defmodule HexWeb.Web.Router do
     release_downloads = nil
     mix_snippet       = nil
     rebar_snippet     = nil
+    hexdocs_url       = nil
+    docs_tarball_url  = nil
+    has_docs          = Enum.any?(releases, fn(release) -> release.has_docs end)
+
+    if has_docs do
+      hexdocs_url = Util.docs_url([package.name])
+      docs_tarball_url = Util.docs_tarball_url(title)
+    end
 
     if current_release do
       release_downloads = ReleaseDownload.release(current_release)
@@ -186,7 +194,8 @@ defmodule HexWeb.Web.Router do
     end
 
     conn = assign_pun(conn, [package, releases, current_release, downloads,
-                             release_downloads, active, title, mix_snippet, rebar_snippet])
+                             release_downloads, active, title, mix_snippet,
+                             rebar_snippet, hexdocs_url, docs_tarball_url])
     send_page(conn, :package)
   end
 

--- a/lib/hex_web/web/templates/package.html.eex
+++ b/lib/hex_web/web/templates/package.html.eex
@@ -50,6 +50,14 @@ build_tools = @current_release && @current_release.meta["build_tools"] || []
           </ul>
         </dd>
       <% end %>
+
+      <%= if @hexdocs_url != nil and @docs_tarball_url != nil do %>
+        <dt>Docs</dt>
+        <dd>
+          <a href="<%= @hexdocs_url %>">online</a>
+          (<a href="<%= @docs_tarball_url %>">download</a>)
+        </dd>
+      <% end %>
     </dl>
     <div style="margin: 10px 0; border-top: 1px solid #eee"></div>
 


### PR DESCRIPTION
Related to: https://github.com/hexpm/hex_web/issues/169

The code checks if any of the package releases have docs (which, if I am not mistaken, confirms that there's a hexdocs.pm page for the package) and renders the link in the template if the docs are present.

Thoughts?