### PR TITLE
Add rel=nofollow to package links

### DIFF
--- a/lib/hex_web/web/templates/package.html.eex
+++ b/lib/hex_web/web/templates/package.html.eex
@@ -45,7 +45,7 @@ build_tools = @current_release && @current_release.meta["build_tools"] || []
         <dd>
           <ul class="links">
             <%= for { name, link } <- links do %>
-              <li><a href="<%= link %>"><%= name %></a></li>
+              <li><a href="<%= link %>" rel="nofollow"><%= name %></a></li>
             <% end %>
           </ul>
         </dd>


### PR DESCRIPTION
Tells search engines not to let this link influence the ranking of the target,
which means one less opportunity for spammers.

https://support.google.com/webmasters/answer/96569?hl=en

Came to think of this when adding links to http://toolbox.elixir.pm.