### PR TITLE
Fix signature digest

### DIFF
--- a/lib/hex_web/util.ex
+++ b/lib/hex_web/util.ex
@@ -254,7 +254,7 @@ defmodule HexWeb.Util do
     [entry | _ ] = :public_key.pem_decode(key)
     key = :public_key.pem_entry_decode(entry)
 
-    :public_key.sign(file, :sha512, key)
+    :public_key.sign({:digest, file}, :sha512, key)
     |> Base.encode16(case: :lower)
   end
 end


### PR DESCRIPTION
This fixes the signing code so that the following can occur in client-side verification:

```elixir
bin = 
  File.read!("registry.ets.gz")
  |> :zlib.gunzip

sig =
  File.read!("registry.ets.gz.signed")
  |> Base.decode16!(case: :lower)

Mix.PublicKey.verify(bin, :sha512, key) # => true
```

I made a mistake in the original code by not passing the file to `:public_key.sign` as a digest.

After this, the client side implementation can occur as shown above.