### PR TITLE
opensearch: use favicon

### DIFF
--- a/priv/static/hexsearch.xml
+++ b/priv/static/hexsearch.xml
@@ -2,4 +2,5 @@
   <ShortName>Hex</ShortName>
   <InputEncoding>utf-8</InputEncoding>
   <Url type="text/html" method="get" template="https://hex.pm/packages?search={searchTerms}&amp;sort=downloads" />
+  <Image height="48" width="48" type="image/png">https://hex.pm/favicon.png</Image>
 </OpenSearchDescription>


### PR DESCRIPTION
I noticed (at least) firefox won't save the favicon for the search, so this should hopefully fix this.