### PR TITLE
Changed allowed auth methods in api router

### DIFF
--- a/lib/hex_web/api/router.ex
+++ b/lib/hex_web/api/router.ex
@@ -254,14 +254,14 @@ defmodule HexWeb.API.Router do
     # Keys
 
     get "keys" do
-      with_authorized(conn, [], fn user ->
+      with_authorized(conn, [only_basic: true], fn user ->
         keys = Key.all(user)
         when_stale(conn, keys, &(&1 |> cache(:private) |> send_render(200, keys)))
       end)
     end
 
     get "keys/:name" do
-      with_authorized(conn, [], fn user ->
+      with_authorized(conn, [only_basic: true], fn user ->
         if key = Key.get(name, user) do
           when_stale(conn, key, &(&1 |> cache(:private) |> send_render(200, key)))
         else
@@ -279,7 +279,7 @@ defmodule HexWeb.API.Router do
     end
 
     delete "keys/:name" do
-      with_authorized(conn, [], fn user ->
+      with_authorized(conn, [only_basic: true], fn user ->
         if key = Key.get(name, user) do
           result = Key.delete(key)
           send_delete_resp(conn, result, :private)

--- a/lib/hex_web/api/util.ex
+++ b/lib/hex_web/api/util.ex
@@ -138,7 +138,7 @@ defmodule HexWeb.API.Util do
 
     result =
       case get_req_header(conn, "authorization") do
-        ["Basic " <> credentials] ->
+        ["Basic " <> credentials] when only_basic ->
           basic_auth(credentials)
         [key] when not only_basic ->
           key_auth(key)

--- a/test/hex_web/api/router_test.exs
+++ b/test/hex_web/api/router_test.exs
@@ -39,17 +39,13 @@ defmodule HexWeb.API.RouterTest do
     :ok
   end
 
-  @doc """
-  Creates and returns an auth key for a given user
-  """
-  @spec test_key_for(String.t) :: String.t
-  def test_key_for(username) when is_binary(username) do
+  @spec test_key_for(String.t | User.t) :: String.t
+  defp test_key_for(username) when is_binary(username) do
     user = user = User.get(username: username)
     test_key_for(user)
   end
-  @spec test_key_for(User.t) :: String.t
-  def test_key_for(user) do
-    {:ok, key} = Key.create(user, %{name: "macbook"})
+  defp test_key_for(user) do
+    {:ok, key} = Key.create(user, %{name: @key_name})
     key.user_secret
   end
 
@@ -726,7 +722,7 @@ defmodule HexWeb.API.RouterTest do
 
     conn = conn("POST", "/api/packages/phoenix/releases/0.0.1/docs", body)
            |> put_req_header("content-type", "application/octet-stream")
-           |> put_req_header("authorization", test_key_for("eric"))
+           |> put_req_header("authorization", test_key_for(user))
     conn = Router.call(conn, [])
     assert conn.status == 201
     assert Release.get(phoenix, "0.0.1").has_docs
@@ -750,7 +746,7 @@ defmodule HexWeb.API.RouterTest do
 
     conn = conn("POST", "/api/packages/phoenix/releases/0.0.2/docs", body)
            |> put_req_header("content-type", "application/octet-stream")
-           |> put_req_header("authorization", test_key_for("eric"))
+           |> put_req_header("authorization", test_key_for(user))
     conn = Router.call(conn, [])
     assert conn.status == 201
 
@@ -783,13 +779,13 @@ defmodule HexWeb.API.RouterTest do
 
     conn = conn("POST", "/api/packages/ecto/releases/0.0.1/docs", body)
            |> put_req_header("content-type", "application/octet-stream")
-           |> put_req_header("authorization", test_key_for("eric"))
+           |> put_req_header("authorization", test_key_for(user))
     conn = Router.call(conn, [])
     assert conn.status == 201
     assert Release.get(ecto, "0.0.1").has_docs
 
     conn = conn("DELETE", "/api/packages/ecto/releases/0.0.1")
-           |> put_req_header("authorization", test_key_for("eric"))
+           |> put_req_header("authorization", test_key_for(user))
     conn = Router.call(conn, [])
     assert conn.status == 204
 
@@ -828,7 +824,7 @@ defmodule HexWeb.API.RouterTest do
 
     conn = conn("POST", "/api/packages/ecto/releases/0.0.1/docs", body)
            |> put_req_header("content-type", "application/octet-stream")
-           |> put_req_header("authorization", test_key_for("eric"))
+           |> put_req_header("authorization", test_key_for(user))
     conn = Router.call(conn, [])
     assert conn.status == 422
     assert %{"errors" => %{"tar" => "directory name not allowed to match a semver version"}} =

--- a/test/hex_web/api/router_test.exs
+++ b/test/hex_web/api/router_test.exs
@@ -10,6 +10,7 @@ defmodule HexWeb.API.RouterTest do
   alias HexWeb.RegistryBuilder
 
   @port Application.get_env(:hex_web, :port)
+  @key_name "macbook"
 
   setup do
     User.create(%{username: "other", email: "other@mail.com", password: "other"}, true)
@@ -36,6 +37,20 @@ defmodule HexWeb.API.RouterTest do
       :inets.start
     end
     :ok
+  end
+
+  @doc """
+  Creates and returns an auth key for a given user
+  """
+  @spec test_key_for(String.t) :: String.t
+  def test_key_for(username) when is_binary(username) do
+    user = user = User.get(username: username)
+    test_key_for(user)
+  end
+  @spec test_key_for(User.t) :: String.t
+  def test_key_for(user) do
+    {:ok, key} = Key.create(user, %{name: "macbook"})
+    key.user_secret
   end
 
   test "create user" do
@@ -117,7 +132,7 @@ defmodule HexWeb.API.RouterTest do
   test "create package key auth" do
     meta = %{name: "ecto", version: "1.0.0", description: "Domain-specific language."}
     conn = conn("POST", "/api/packages/ecto/releases", create_tar(meta, []))
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
 
     assert conn.status == 201
@@ -135,7 +150,7 @@ defmodule HexWeb.API.RouterTest do
 
     meta = %{name: "ecto", version: "1.0.0", description: "awesomeness"}
     conn = conn("POST", "/api/packages/ecto/releases", create_tar(meta, []))
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization",  test_key_for("eric"))
     conn = Router.call(conn, [])
 
     assert conn.status == 201
@@ -148,7 +163,7 @@ defmodule HexWeb.API.RouterTest do
   test "create package authorizes" do
     meta = %{name: "ecto", version: "1.0.0", description: "Domain-specific language."}
     conn = conn("POST", "/api/packages/ecto/releases", create_tar(meta, []))
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:WRONG"))
+           |> put_req_header("authorization", "WRONG")
     conn = Router.call(conn, [])
 
     assert conn.status == 401
@@ -160,17 +175,17 @@ defmodule HexWeb.API.RouterTest do
 
     meta = %{name: "ecto", version: "1.0.0", description: "Domain-specific language."}
     conn = conn("POST", "/api/packages/ecto/releases", create_tar(meta, []))
-           |> put_req_header("authorization", "Basic " <> :base64.encode("other:other"))
+           |> put_req_header("authorization", "invalid-key")
     conn = Router.call(conn, [])
 
-    assert conn.status == 403
+    assert conn.status == 401
     assert get_resp_header(conn, "www-authenticate") == ["Basic realm=hex"]
   end
 
   test "create package validates" do
     meta = %{name: "ecto", version: "1.0.0", links: "invalid", description: "description"}
     conn = conn("POST", "/api/packages/ecto/releases", create_tar(meta, []))
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
 
     assert conn.status == 422
@@ -182,7 +197,7 @@ defmodule HexWeb.API.RouterTest do
   test "create releases" do
     body = create_tar(%{name: :postgrex, app: "not_postgrex", version: "0.0.1", description: "description"}, [])
     conn = conn("POST", "/api/packages/postgrex/releases", body)
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
 
     assert conn.status == 201
@@ -192,7 +207,7 @@ defmodule HexWeb.API.RouterTest do
 
     body = create_tar(%{name: :postgrex, version: "0.0.2", description: "description"}, [])
     conn = conn("POST", "/api/packages/postgrex/releases", body)
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
 
     assert conn.status == 201
@@ -211,7 +226,7 @@ defmodule HexWeb.API.RouterTest do
 
     body = create_tar(%{name: :phoenix, app: "phoenix", description: "Web framework", version: "1.0.0"}, [])
     conn = conn("POST", "/api/packages/phoenix/releases", body)
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 201
 
@@ -221,12 +236,12 @@ defmodule HexWeb.API.RouterTest do
   test "update release" do
     body = create_tar(%{name: :postgrex, version: "0.0.1", description: "description"}, [])
     conn = conn("POST", "/api/packages/postgrex/releases", body)
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 201
 
     conn = conn("POST", "/api/packages/postgrex/releases", body)
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 200
 
@@ -238,7 +253,7 @@ defmodule HexWeb.API.RouterTest do
     |> HexWeb.Repo.update!
 
     conn = conn("POST", "/api/packages/postgrex/releases", body)
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 422
     assert %{"errors" => %{"inserted_at" => "can only modify a release up to one hour after creation"}} =
@@ -248,7 +263,7 @@ defmodule HexWeb.API.RouterTest do
   test "delete release" do
     body = create_tar(%{name: :postgrex, version: "0.0.1", description: "description"}, [])
     conn = conn("POST", "/api/packages/postgrex/releases", body)
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 201
 
@@ -257,7 +272,7 @@ defmodule HexWeb.API.RouterTest do
     |> HexWeb.Repo.update!
 
     conn = conn("POST", "/api/packages/postgrex/releases", body)
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 422
     assert %{"errors" => %{"inserted_at" => "can only modify a release up to one hour after creation"}} =
@@ -267,7 +282,7 @@ defmodule HexWeb.API.RouterTest do
     |> HexWeb.Repo.update!
 
     conn = conn("DELETE", "/api/packages/postgrex/releases/0.0.1")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 204
 
@@ -279,7 +294,7 @@ defmodule HexWeb.API.RouterTest do
   test "create release authorizes" do
     body = create_tar(%{name: :postgrex, version: "0.0.1"}, [])
     conn = conn("POST", "/api/packages/postgrex/releases", body)
-           |> put_req_header("authorization", "Basic " <> :base64.encode("other:other"))
+           |> put_req_header("authorization", test_key_for("other"))
     conn = Router.call(conn, [])
 
     assert conn.status == 403
@@ -290,7 +305,7 @@ defmodule HexWeb.API.RouterTest do
     reqs = %{decimal: %{requirement: "~> 0.0.1", app: "not_decimal"}}
     body = create_tar(%{name: :postgrex, version: "0.0.1", requirements: reqs, description: "description"}, [])
     conn = conn("POST", "/api/packages/postgrex/releases", body)
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
 
     assert conn.status == 201
@@ -310,7 +325,7 @@ defmodule HexWeb.API.RouterTest do
     reqs = %{decimal: %{requirement: "~> 0.0.1"}}
     body = create_tar(%{name: :postgrex, version: "0.0.1", requirements: reqs, description: "description"}, [])
     conn = conn("POST", "/api/packages/postgrex/releases", body)
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 201
 
@@ -394,7 +409,7 @@ defmodule HexWeb.API.RouterTest do
   test "get user" do
     conn = conn("GET", "/api/users/eric")
            |> put_req_header("content-type", "application/json")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 200
 
@@ -584,7 +599,7 @@ defmodule HexWeb.API.RouterTest do
 
   test "get package owners" do
     conn = conn("GET", "/api/packages/postgrex/owners")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 200
 
@@ -596,7 +611,7 @@ defmodule HexWeb.API.RouterTest do
     Package.add_owner(package, user)
 
     conn = conn("GET", "/api/packages/postgrex/owners")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 200
 
@@ -608,33 +623,33 @@ defmodule HexWeb.API.RouterTest do
 
   test "get package owners authorizes" do
     conn = conn("GET", "/api/packages/postgrex/owners")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("other:other"))
+           |> put_req_header("authorization", test_key_for("other"))
     conn = Router.call(conn, [])
     assert conn.status == 403
   end
 
   test "check if user is package owner" do
     conn = conn("GET", "/api/packages/postgrex/owners/eric@mail.com")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 204
 
     conn = conn("GET", "/api/packages/postgrex/owners/jose@mail.com")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 404
   end
 
   test "check if user is package owner authorizes" do
     conn = conn("GET", "/api/packages/postgrex/owners/eric@mail.com")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("other:other"))
+           |> put_req_header("authorization", test_key_for("other"))
     conn = Router.call(conn, [])
     assert conn.status == 403
   end
 
   test "add package owner" do
     conn = conn("PUT", "/api/packages/postgrex/owners/jose%40mail.com")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 204
 
@@ -646,7 +661,7 @@ defmodule HexWeb.API.RouterTest do
 
   test "add package owner authorizes" do
     conn = conn("PUT", "/api/packages/postgrex/owners/jose%40mail.com")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("other:other"))
+           |> put_req_header("authorization", test_key_for("other"))
     conn = Router.call(conn, [])
     assert conn.status == 403
   end
@@ -657,14 +672,14 @@ defmodule HexWeb.API.RouterTest do
     Package.add_owner(package, user)
 
     conn = conn("DELETE", "/api/packages/postgrex/owners/jose%40mail.com")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 204
 
     assert [%User{username: "eric"}] = Package.owners(package)
 
     conn = conn("DELETE", "/api/packages/postgrex/owners/jose%40mail.com")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 204
 
@@ -673,7 +688,7 @@ defmodule HexWeb.API.RouterTest do
 
   test "delete package owner authorizes" do
     conn = conn("DELETE", "/api/packages/postgrex/owners/eric%40mail.com")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("other:other"))
+           |> put_req_header("authorization", test_key_for("other"))
     conn = Router.call(conn, [])
     assert conn.status == 403
   end
@@ -692,7 +707,7 @@ defmodule HexWeb.API.RouterTest do
 
     conn = conn("POST", "/api/packages/phoenix/releases/0.0.1/docs", body)
            |> put_req_header("content-type", "application/octet-stream")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 201
     assert Release.get(phoenix, "0.0.1").has_docs
@@ -716,7 +731,7 @@ defmodule HexWeb.API.RouterTest do
 
     conn = conn("POST", "/api/packages/phoenix/releases/0.0.2/docs", body)
            |> put_req_header("content-type", "application/octet-stream")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 201
 
@@ -749,13 +764,13 @@ defmodule HexWeb.API.RouterTest do
 
     conn = conn("POST", "/api/packages/ecto/releases/0.0.1/docs", body)
            |> put_req_header("content-type", "application/octet-stream")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 201
     assert Release.get(ecto, "0.0.1").has_docs
 
     conn = conn("DELETE", "/api/packages/ecto/releases/0.0.1")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 204
 
@@ -794,7 +809,7 @@ defmodule HexWeb.API.RouterTest do
 
     conn = conn("POST", "/api/packages/ecto/releases/0.0.1/docs", body)
            |> put_req_header("content-type", "application/octet-stream")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", test_key_for("eric"))
     conn = Router.call(conn, [])
     assert conn.status == 422
     assert %{"errors" => %{"tar" => "directory name not allowed to match a semver version"}} =

--- a/test/hex_web/router_test.exs
+++ b/test/hex_web/router_test.exs
@@ -48,11 +48,20 @@ defmodule HexWeb.RouterTest do
       Application.put_env(:hex_web, :store, HexWeb.Store.S3)
     end
 
+    body = %{name: "integration-test"}
+    conn = conn("POST", "/api/keys", Poison.encode!(body))
+           |> put_req_header("content-type", "application/json")
+           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+    conn = Router.call(conn, [])
+    assert conn.status == 201
+    body = Poison.decode!(conn.resp_body)
+    %{"secret" => api_key} = body
+
     reqs = %{decimal: %{requirement: "~> 0.0.1"}}
     body = create_tar(%{name: :postgrex, version: "0.0.1", requirements: reqs, description: "description"}, [])
     conn = conn("POST", "/api/packages/postgrex/releases", body)
            |> put_req_header("content-type", "application/octet-stream")
-           |> put_req_header("authorization", "Basic " <> :base64.encode("eric:eric"))
+           |> put_req_header("authorization", api_key)
            |> Router.call([])
     assert conn.status == 201
 


### PR DESCRIPTION
#196 This PR disables basic auth from all routes except for `api/keys/` and `keys` router now only accepts basic authorization method. 