### PR TITLE
Remove extra comma from config

### DIFF
--- a/config/hex.exs
+++ b/config/hex.exs
@@ -10,7 +10,7 @@ config :hex_web,
   secret:       System.get_env("HEX_SECRET")   || "796f75666f756e64746865686578"
 
 config :hex_web, HexWeb.Endpoint,
-  http: [port: 4043],
+  http: [port: 4043]
 
 config :hex_web, HexWeb.Repo,
   adapter: Ecto.Adapters.Postgres,


### PR DESCRIPTION
Right now this causes an error when trying to run `mix test` from hex locally:

```
** (Mix.Config.LoadError) could not load config config/hex.exs
    ** (SyntaxError) config/hex.exs:15: syntax error before: config
    (elixir) lib/code.ex:168: Code.eval_string/3
    (mix) lib/mix/config.ex:150: Mix.Config.read!/1
    (mix) lib/mix/config.ex:182: anonymous fn/2 in Mix.Config.read_wildcard!/1
    (elixir) lib/enum.ex:1473: Enum."-reduce/3-lists^foldl/2-0-"/3
    (stdlib) erl_eval.erl:669: :erl_eval.do_apply/6
    (stdlib) erl_eval.erl:877: :erl_eval.expr_list/6

** (MatchError) no match of right hand side value: 1
    (hex) test/support/hex_web.ex:100: HexTest.HexWeb.cmd/2
    (hex) test/support/hex_web.ex:24: HexTest.HexWeb.init/0
    test/test_helper.exs:15: (file)
    (elixir) lib/code.ex:363: Code.require_file/2
    (elixir) lib/enum.ex:604: Enum."-each/2-lists^foreach/1-0-"/2
```