### PR TITLE
Update task doc to update deprecated key

### DIFF
--- a/web/templates/docs/tasks.html.eex
+++ b/web/templates/docs/tasks.html.eex
@@ -226,7 +226,7 @@ recommended to do so.</p>
 can include wildcards. Defaults to `["lib", "priv", "mix.exs", "README*",
 "readme*", "LICENSE*", "license*", "CHANGELOG*", "changelog*", "src"]`.</p>
 </li>
-<li><p><code class="inline">:contributors</code> - List of names of contributors.</p>
+<li><p><code class="inline">:maintainers</code> - List of names of maintainers.</p>
 </li>
 <li><p><code class="inline">:licenses</code> - List of licenses used by the package.</p>
 </li>


### PR DESCRIPTION
`:contributors` as part of the package meta in `mix.exs` was deprecated after Hex v0.9.0 and `:maintainers` is now the favoured way to supply names.

This commit simply updates the Hex.pm documentation to showcase that.