### PR TITLE
Make footer sticky

### DIFF
--- a/web/static/css/main.scss
+++ b/web/static/css/main.scss
@@ -13,6 +13,15 @@
 @import "template/package-view";
 @import "template/page";
 
+html {
+  min-height: 100%;
+  position: relative;
+}
+
+body {
+  margin-bottom: 88px;
+}
+
 /* Responsive: Portrait tablets and up */
 @media screen and (min-width: 768px) {
   .container {

--- a/web/static/css/template/_footer.scss
+++ b/web/static/css/template/_footer.scss
@@ -1,5 +1,9 @@
 .footer {
-  margin-top: 50px;
+  padding-top: 50px;
+  height: 88px;
+  width: 100%;
+  position: absolute;
+  bottom: 0;
   .made-with-love {
     text-align: center;
     font-size: 15px;


### PR DESCRIPTION
On a larger screen on some the package pages, the footer would display
in the middle of the page. These changes make the footer behave as
before, except on a large resolution it will be stuck to the bottom of
the page.