### PR TITLE
Fix offsetted anchors on the mix tasks list page

### DIFF
--- a/web/static/css/main.scss
+++ b/web/static/css/main.scss
@@ -12,6 +12,7 @@
 @import "template/package-list";
 @import "template/package-view";
 @import "template/page";
+@import "template/docs";
 
 /* Responsive: Portrait tablets and up */
 @media screen and (min-width: 768px) {

--- a/web/static/css/template/_docs.scss
+++ b/web/static/css/template/_docs.scss
@@ -1,0 +1,3 @@
+#mix-tasks h3 {
+  padding-top: 90px; margin-top: -90px;
+}

--- a/web/templates/docs/tasks.html.eex
+++ b/web/templates/docs/tasks.html.eex
@@ -1,4 +1,4 @@
-<div class="container page">
+<div class="container page" id="mix-tasks">
 <h2>
   Mix tasks
 </h2>


### PR DESCRIPTION
See e.g. https://hexpm-frontend.herokuapp.com/docs/tasks#hex_config

Covers:

•  Fix anchors on docs page, the fixed header covers the anchor
