### PR TITLE
Remove Getting started section and make "Using with ..." clickable

### DIFF
--- a/web/static/css/template/_home.scss
+++ b/web/static/css/template/_home.scss
@@ -51,6 +51,10 @@
 .using-with-box {
   position: relative;
   margin-bottom: 40px;
+
+  h3 a {
+    color: #4f2e85;
+  }
 }
 .shadow {
   background: #8f9198;
@@ -146,31 +150,6 @@
         }
       }
     }
-  }
-}
-
-
-.getting-started {
-  padding-bottom: 40px;
-  h2 {
-    text-align: center;
-    text-transform: uppercase;
-    font-size: 22px;
-    font-weight: bold;
-    margin-bottom: 30px;
-  }
-  a {
-    color: #4f2e85;
-    font-size: 24px;
-    line-height: 28px;
-    display: block;
-    margin-bottom: 6px;
-  }
-  p {
-    font-size: 18px;
-    line-height: 18px;
-    font-weight: 300;
-    color: #000000;
   }
 }
 

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -24,7 +24,7 @@
           <div class="lang-symbol"></div>
         </div>
         <div class="instructions">
-          <h3>Using with Elixir</h3>
+          <h3><a href="<%= docs_path(HexWeb.Endpoint, :usage) %>">Using with Elixir</a></h3>
           <p>
             Simply specify your Mix dependencies as two-item tuples like  <span class="code">{:ecto, "~> 0.1.0"}</span>  and Elixir will ask if you want to install Hex if you haven't already.
             After installed, you can run <span class="code">$ mix local </span> to see all available Hex tasks and  <span class="code">$ mix help TASK</span> for more information about a specific task.
@@ -40,32 +40,12 @@
           <div class="lang-symbol"></div>
         </div>
         <div class="instructions">
-          <h3>Using with Erlang</h3>
+          <h3><a href="<%= docs_path(HexWeb.Endpoint, :rebar3_usage) %>">Using with Erlang</a></h3>
           <p>
             Download <a href="https://s3.amazonaws.com/rebar3/rebar3">rebar3</a>, put it in your <span class="code">PATH</span> and give it executable permissions.
             Now you can specify Hex dependencies in your rebar.config like <span class="code">{deps, [hackney]}</span>.
           </p>
         </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="getting-started">
-  <div class="container">
-    <h2>Getting Started</h2>
-    <div class="row">
-      <div class="col-md-4">
-        <a href="/docs/usage">installing</a>
-        <p>Mix will automatically prompt you whenever there is a need to use Hex.</p>
-      </div>
-      <div class="col-md-4">
-        <a href="#">screencasts and docs</a>
-        <p>Mix will automatically prompt you whenever there is a need to use Hex...</p>
-      </div>
-      <div class="col-md-4">
-        <a href="#">community</a>
-        <p>Mix will automatically prompt you whenever there is a need to use Hex...</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Not sure if I chose the best color for the "Using with ...". I wanted to make it more prominent by picking something different than black. By default it would have been the "red" color which looked kinda weird.

Before: ![before](https://cloud.githubusercontent.com/assets/76071/14583848/16bf72c4-042f-11e6-97f8-3af7fb60494c.png)

After: ![after](https://cloud.githubusercontent.com/assets/76071/14583849/188b9ee8-042f-11e6-83a0-138c8fe43848.png)