### PR TITLE
Move Headers for latest downloads

### DIFF
--- a/web/static/css/template/_home.scss
+++ b/web/static/css/template/_home.scss
@@ -220,7 +220,7 @@ only screen and (        min-device-pixel-ratio: 3) {
 
 .log-head {
   border-bottom: #4f2e85 1px solid;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
   padding-bottom: 10px;
   color: #000000;
   font-weight: 300;

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -101,26 +101,11 @@
   </ul>
 </div>
 
-<div class="log-head">
-  <div class="container">
-    <div class="row">
-      <div class="col-md-4">
-        Most Downloaded
-      </div>
-      <div class="col-md-4">
-        New Packages
-      </div>
-      <div class="col-md-4">
-        Recently Updated
-      </div>
-    </div>
-  </div>
-</div>
-
 <div class="log-body">
   <div class="container">
     <div class="row">
       <div class="col-md-4">
+        <h3 class="log-head">Most Downloaded</h3>
         <ul>
           <%= for {package, inserted_at, meta, downloads} <- @package_top do %>
             <%= render_package package: package, downloads: downloads, inserted_at: inserted_at, description: meta.description %>
@@ -128,6 +113,7 @@
         </ul>
       </div>
       <div class="col-md-4">
+        <h3 class="log-head">New Packages</h3>
         <ul>
           <%= for {package, inserted_at, %PackageMetadata{} = meta} <- @package_new do %>
             <%= render_package package: package, inserted_at: inserted_at, description: meta.description %>
@@ -135,6 +121,7 @@
         </ul>
       </div>
       <div class="col-md-4">
+        <h3 class="log-head">Recently Updated</h3>
         <ul>
           <%= for {package, version, inserted_at, %PackageMetadata{} = meta} <- @releases_new do %>
             <%= render_package version: version, package: package, inserted_at: inserted_at, description: meta.description %>


### PR DESCRIPTION
**Before**
Normal:
 
<img width="1052" alt="screen shot 2016-04-16 at 8 15 54 pm" src="https://cloud.githubusercontent.com/assets/301291/14584872/0f4098a6-0412-11e6-89e6-801516edfc0a.png">

Mobile:
<img width="386" alt="screen shot 2016-04-16 at 8 29 02 pm" src="https://cloud.githubusercontent.com/assets/301291/14584874/19fd7ac0-0412-11e6-9a5c-bc3a6f57d43d.png">


**After**
Normal:
<img width="1415" alt="screen shot 2016-04-16 at 8 29 27 pm" src="https://cloud.githubusercontent.com/assets/301291/14584875/238ab7ba-0412-11e6-8a96-b7dca797badf.png">

Mobile:
 
<img width="479" alt="screen shot 2016-04-16 at 8 29 17 pm" src="https://cloud.githubusercontent.com/assets/301291/14584878/2ee4f9cc-0412-11e6-9af4-07bcc092940a.png">
