### PR TITLE
Only show border on last paragraph of package description

### DIFF
--- a/web/static/css/template/_package-view.scss
+++ b/web/static/css/template/_package-view.scss
@@ -22,6 +22,9 @@
     padding: 28px 0 15px 0;
     line-height: 20px;
     font-weight: 300;
+  }
+
+  .description:last-of-type {
     border-bottom: #cccccc 1px solid;
   }
 }


### PR DESCRIPTION
After https://github.com/hexpm/hex_web/commit/d3d6e388bbba708048373e3bba33984b13f57493, a bottom border is shown after each paragraph in the description, in case the description takes several paragraphs, as the `text_to_html` helper applies the class `.description` to every paragraph:

![captura de pantalla 2016-04-19 a las 16 05 10](https://cloud.githubusercontent.com/assets/2629/14642062/47157830-0649-11e6-8f3e-138f67982f42.png)

This PR applies the bottom border only to the last paragraph:

![captura de pantalla 2016-04-19 a las 16 06 05](https://cloud.githubusercontent.com/assets/2629/14642074/5959550c-0649-11e6-8d46-4387baa66912.png)


