### PR TITLE
Sorting info for default param, relocated tests

### DIFF
--- a/test/views/package_view_test.exs
+++ b/test/views/package_view_test.exs
@@ -1,0 +1,21 @@
+defmodule HexWeb.PackageViewTest do
+  use HexWeb.ConnCase, async: true
+
+  import Phoenix.View
+  alias HexWeb.PackageView
+
+  test "show sort info" do
+    assert PackageView.show_sort_info("name") == "(Sorted by name)"
+    assert PackageView.show_sort_info("inserted_at") == "(Sorted by recently created)"
+    assert PackageView.show_sort_info("updated_at") == "(Sorted by recently updated)"
+    assert PackageView.show_sort_info("downloads") == "(Sorted by downloads)"
+  end
+
+  test "show sort info when sort param is not available" do
+    assert PackageView.show_sort_info("some param") == nil
+  end
+
+  test "show sort info when sort param is nil" do
+    assert PackageView.show_sort_info(nil) == "(Sorted by name)"
+  end
+end

--- a/test/views/page_view_test.exs
+++ b/test/views/page_view_test.exs
@@ -1,16 +1,3 @@
 defmodule HexWeb.PageViewTest do
   use HexWeb.ConnCase, async: true
-
-  import Phoenix.View
-  alias HexWeb.PackageView
-
-  test "show sort info" do
-    assert PackageView.show_sort_info("name") == "(Sorted by name)"
-    assert PackageView.show_sort_info("inserted_at") == "(Sorted by recently created)"
-    assert PackageView.show_sort_info("downloads") == "(Sorted by downloads)"
-  end
-
-  test "show sort info when sort param is not available" do
-    assert PackageView.show_sort_info("some param") == nil
-  end
 end

--- a/web/views/package_view.ex
+++ b/web/views/package_view.ex
@@ -1,8 +1,12 @@
 defmodule HexWeb.PackageView do
   use HexWeb.Web, :view
 
+  def show_sort_info(nil), do: "(Sorted by name)"
   def show_sort_info(param) do
-    available_params = %{"name" => "name", "inserted_at" => "recently created", "downloads" => "downloads"}
+    available_params = %{
+      "name" => "name", "inserted_at" => "recently created",
+      "downloads" => "downloads", "updated_at" => "recently updated"}
+
     if Map.has_key?(available_params, param), do: "(Sorted by #{available_params[param]})"
   end
 end


### PR DESCRIPTION
Added sorting info for nil param, relocated tests and added info for the sorting by updated_at. Also I found that sorting selectbox has not content "recently updated" option. It was planned, or forgot to add?