### PR TITLE
Upgrade OpenSearch File

### DIFF
--- a/lib/hex_web/endpoint.ex
+++ b/lib/hex_web/endpoint.ex
@@ -10,7 +10,7 @@ defmodule HexWeb.Endpoint do
   plug Plug.Static,
     at: "/", from: :hex_web, gzip: true,
     only: ~w(css fonts images js),
-    only_matching: ~w(favicon hexsearch robots)
+    only_matching: ~w(favicon robots)
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.

--- a/web/controllers/opensearch_controller.ex
+++ b/web/controllers/opensearch_controller.ex
@@ -1,0 +1,9 @@
+defmodule HexWeb.OpenSearchController do
+  use HexWeb.Web, :controller
+
+  def opensearch(conn, _params) do
+    conn
+    |> put_resp_content_type("text/xml")
+    |> render("opensearch.xml")
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -52,6 +52,7 @@ defmodule HexWeb.Router do
 
   scope "/", HexWeb do
     get "sitemap.xml", SitemapController, :sitemap
+    get "hexsearch.xml", OpenSearchController, :opensearch
     get "installs/hex.ez", InstallerController, :get_archive
 
     # TODO: Check if we can replace this

--- a/web/static/assets/hexsearch.xml
+++ b/web/static/assets/hexsearch.xml
@@ -1,5 +1,0 @@
-<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-  <ShortName>Hex</ShortName>
-  <InputEncoding>utf-8</InputEncoding>
-  <Url type="text/html" method="get" template="https://hex.pm/packages?search={searchTerms}&amp;sort=downloads" />
-</OpenSearchDescription>

--- a/web/templates/layout/header.html.eex
+++ b/web/templates/layout/header.html.eex
@@ -8,7 +8,7 @@
 
     <title><%= title(assigns) %></title>
 
-    <link rel="search" type="application/opensearchdescription+xml" title="Hex" href="<%= static_path(HexWeb.Endpoint, "/hexsearch.xml") %>">
+    <link rel="search" type="application/opensearchdescription+xml" title="Hex" href="/hexsearch.xml">
     <link rel="stylesheet" href="<%= static_path(HexWeb.Endpoint, "/css/main.css") %>">
     <link rel="shortcut icon" href="<%= static_path(HexWeb.Endpoint, "/favicon.png") %>">
   </head>

--- a/web/templates/open_search/opensearch.xml.eex
+++ b/web/templates/open_search/opensearch.xml.eex
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Hex</ShortName>
+  <Description>Search for packages on Hex.pm.</Description>
+  <Contact>support@hex.pm</Contact>
+  <AdultContent>false</AdultContent>
+  <Language>en-us</Language>
+
+  <Image height="48" width="48" type="image/x-icon">
+    <%= static_url(HexWeb.Endpoint, "/favicon.ico") %>
+  </Image>
+
+  <Image height="48" width="48" type="image/png">
+     <%= static_url(HexWeb.Endpoint, "/favicon.png") %>
+  </Image>
+
+  <InputEncoding>utf-8</InputEncoding>
+  <OutputEncoding>utf-8</OutputEncoding>
+  <Url type="text/html" method="get" template="<%= package_url(HexWeb.Endpoint, :index) %>?search={searchTerms}&amp;sort=downloads" />
+</OpenSearchDescription>

--- a/web/views/opensearch_view.ex
+++ b/web/views/opensearch_view.ex
@@ -1,0 +1,3 @@
+defmodule HexWeb.OpenSearchView do
+  use HexWeb.Web, :view
+end


### PR DESCRIPTION
Closes #307. Moves the hexsearch file into a template in order to use `static_path()`.

**Note**: Currently, the file uses 48x48 images. The specification suggests 64x images, so this needs to be changed