### PR TITLE
Adds missing alt attribute in images

### DIFF
--- a/web/templates/page/sponsors.html.eex
+++ b/web/templates/page/sponsors.html.eex
@@ -5,7 +5,7 @@
 <div class="sponsors container">
   <div class="row">
     <div class="col-md-4 image">
-      <a href="http://pages.plataformatec.com.br/elixir-phoenix-consulting"><img src="<%= static_path(HexWeb.Endpoint, "/images/plataformatec.png") %>"></a>
+      <a href="http://pages.plataformatec.com.br/elixir-phoenix-consulting"><img src="<%= static_path(HexWeb.Endpoint, "/images/plataformatec.png") %>" alt="Plataformatec logo"></a>
     </div>
     <div class="col-md-8">
       <p>
@@ -19,7 +19,7 @@
 
   <div class="row">
     <div class="col-md-4 image">
-      <a href="https://www.fastly.com/"><img src="<%= static_path(HexWeb.Endpoint, "/images/fastly.png") %>"></a>
+      <a href="https://www.fastly.com/"><img src="<%= static_path(HexWeb.Endpoint, "/images/fastly.png") %>" alt="Fastly logo"></a>
     </div>
     <div class="col-md-8">
       <p>


### PR DESCRIPTION
This fixes HTML markup in sponsors page, images require an `alt` attribute to make them accessible.