### PR TITLE
Fix pagination-dropdown styles

### DIFF
--- a/web/static/css/base/_mixins.scss
+++ b/web/static/css/base/_mixins.scss
@@ -31,6 +31,7 @@
 		font-style: $style;
 	}
 }
+
 @mixin clear-fix() {
 	&:after {
 	   content: " "; /* Older browser do not support empty content */

--- a/web/static/css/base/_variables.scss
+++ b/web/static/css/base/_variables.scss
@@ -3,15 +3,24 @@
 *********************************************************************/
 $color-white:         #ffffff;
 $color-black:         #000000;
-$color-red:           #a93e42;
+$color-red:           #aa2c3f;
 $color-light-red:     #e75458;
-$color-puple:         #e75458;
-$color-light-purple:  #e75458;
+$color-grey:          #d1d3d7;
 
 /*********************************************************************
 *  Typography
 *********************************************************************/
-$base-font-size: 				10;
-$base-line-height:  			16;
-$base-font-family: 				'Lato', sans-serif;
-$base-title-font-family: 		'Lato', sans-serif;
+$base-font-size:          10;
+$base-line-height:        16;
+$base-font-family:        'Lato', sans-serif;
+$base-title-font-family:  'Lato', sans-serif;
+
+/*********************************************************************
+* Font Colors
+*********************************************************************/
+$text-grey: #5c676d;
+
+/*********************************************************************
+* Border
+*********************************************************************/
+$base-border-color: $color-grey 1px solid;

--- a/web/static/css/base/_variables.scss
+++ b/web/static/css/base/_variables.scss
@@ -16,11 +16,12 @@ $base-font-family:        'Lato', sans-serif;
 $base-title-font-family:  'Lato', sans-serif;
 
 /*********************************************************************
-* Font Colors
+*  Font Colors
 *********************************************************************/
 $text-grey: #5c676d;
 
 /*********************************************************************
-* Border
+*  Elements
 *********************************************************************/
-$base-border-color: $color-grey 1px solid;
+$base-border: 1px solid $color-grey;
+$base-box-shadow: 0px 1px 4px rgba(0,0,0,0.2);

--- a/web/static/css/template/_package-list.scss
+++ b/web/static/css/template/_package-list.scss
@@ -9,7 +9,7 @@
   & {
     list-style: none;
     text-align: center;
-    border: $base-border-color;
+    border: $base-border;
     border-left: none;
     border-right: none;
     padding: 15px 0;
@@ -35,9 +35,11 @@
   }
 }
 
-.letter-sort {
+.letter-sort > .list {
   @include general-mobile {
-    .list > li {
+    box-shadow: $base-box-shadow;
+
+     > li {
       margin: 10px;
     }
   }
@@ -95,29 +97,22 @@
   float: right;
 }
 
-.pagination-info {
-  & {
-    float: left;
-    color: #5c676d;
-    @include font-size(16 , $base-line-height);
-    padding: 10px;
-    font-weight: 300;
-  }
+.pagination-info,
+.pagination-sort {
+  float: left;
+  color: $text-grey;
+  @include font-size(16, $base-line-height);
+  padding: 10px;
+  font-weight: 300;
+}
 
+.pagination-info {
   @include general-mobile {
     padding: 10px 0;
   }
 }
 
 .pagination-sort {
-  & {
-    float: left;
-    color: #5c676d;
-    @include font-size(16 , $base-line-height);
-    padding: 10px;
-    font-weight: 300;
-  }
-
   @include general-mobile {
     float: right;
     padding: 10px 0;

--- a/web/static/css/template/_package-list.scss
+++ b/web/static/css/template/_package-list.scss
@@ -4,28 +4,41 @@
   margin: 40px 0;
   color: #5c676d;
 }
-.by-letters {
-  ul {
+
+.letter-sort > .list {
+  & {
     list-style: none;
     text-align: center;
-    border: #d1d3d7 1px solid;
+    border: $base-border-color;
     border-left: none;
     border-right: none;
     padding: 15px 0;
     margin: 0;
-    li {
-      display: inline-block;
-      @include font-size(22 , $base-line-height);
-      @include line-height(36);
-      text-transform: uppercase;
-      margin: 0 8px;
-      a {
-        color: #5c676d;
-        font-weight: 300;
-        &:hover {
-          color: #aa2c3f;
-        }
-      }
+  }
+
+  > li {
+    display: inline-block;
+    font-size: 20px;
+    @include font-size(22 , $base-line-height);
+    @include line-height(36);
+    text-transform: uppercase;
+    margin: 0 8px;
+  }
+
+  > li > a {
+    color: $text-grey;
+    font-weight: 300;
+  }
+
+  > li > a:hover {
+    color: $color-red;
+  }
+}
+
+.letter-sort {
+  @include general-mobile {
+    .list > li {
+      margin: 10px;
     }
   }
 }
@@ -81,13 +94,36 @@
 .pagination-widget {
   float: right;
 }
+
 .pagination-info {
-  float: left;
-  color: #5c676d;
-  @include font-size(16 , $base-line-height);
-  padding: 10px;
-  font-weight: 300;
+  & {
+    float: left;
+    color: #5c676d;
+    @include font-size(16 , $base-line-height);
+    padding: 10px;
+    font-weight: 300;
+  }
+
+  @include general-mobile {
+    padding: 10px 0;
+  }
 }
+
+.pagination-sort {
+  & {
+    float: left;
+    color: #5c676d;
+    @include font-size(16 , $base-line-height);
+    padding: 10px;
+    font-weight: 300;
+  }
+
+  @include general-mobile {
+    float: right;
+    padding: 10px 0;
+  }
+}
+
 .pagination {
   margin: 0;
 

--- a/web/templates/package/index.html.eex
+++ b/web/templates/package/index.html.eex
@@ -4,8 +4,8 @@
 </h2>
 
 <%= unless @conn.params["search"] do %>
-  <div class="by-letters">
-    <ul>
+  <div class="letter-sort">
+    <ul class="list">
       <%= for letter <- @letters do %>
       <li>
         <a href="<%= package_path(HexWeb.Endpoint, :index, letter: letter) %>">
@@ -43,7 +43,7 @@
     <h4 class="results-found"><%= @package_count %> Results Found</h4>
     <%= show_sort_info(@conn.params["sort"]) %>
   </div>
-  <div class="navbar-right pagination-info">
+  <div class="navbar-right pagination-sort">
     <%= unless @letter do %>
       <div class="dropdown">
         <button class="btn btn-default dropdown-toggle" type="button" id="sort_dropdown" data-toggle="dropdown">


### PR DESCRIPTION
- [x] Add space between the letters
- [x] Align the `Sort By` dropdown to the right
- [x] Remove unused variables in `variables.scss`

In reference to [this](https://github.com/hexpm/hex_web/issues/313) issue.

Mobile view:
![screenshot 2016-05-12 00 58 35](https://cloud.githubusercontent.com/assets/7468021/15189581/1ed394b4-17de-11e6-9176-37e4dc34c0cd.png)

Web view:
![screenshot 2016-05-12 01 23 27](https://cloud.githubusercontent.com/assets/7468021/15190001/4cca61f2-17e0-11e6-8e9e-4bf5f6973986.png)
