### PR TITLE
DB seeds improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ mix ecto.migrate HexWeb.Repo
 Using the following command you can seed your local HexWeb instance with some sample data:
 
 ```shell
-mix run scripts/sample_data.exs
+mix run priv/repo/seeds.exs
+```
+
+Also, all of the steps above (creating, migrating, and seeding the database) can be achieved by running:
+
+```shell
+mix ecto.setup
 ```
 
 ### Running HexWeb

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule HexWeb.Mixfile do
 
   defp aliases do
     ["ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
-     "ecto.reset": ["ecto.drop", "ecto.setup"],
+     "ecto.reset": ["ecto.drop", "ecto.create", "ecto.migrate"],
      "test": ["ecto.migrate", "test"]]
   end
 end


### PR DESCRIPTION
This does two things:
- updates README
- seeds with sample data only in dev. When testing more complicated migrations I sometimes just nuked the db with `MIX_ENV=test mix ecto.reset` which before this patch would put unwanted data from seeds into the test db. Shame the diff and git history is a mess because of this change.