### PR TITLE
Fix JSON iso8601 dates not including timezone (fixes #340)

### DIFF
--- a/lib/hex_web/ecto_poison_datetime_override.ex
+++ b/lib/hex_web/ecto_poison_datetime_override.ex
@@ -1,0 +1,10 @@
+# TODO: Revisit for Elixir 1.3, which will be adding native DateTime support
+
+if Code.ensure_loaded?(Poison) and Code.ensure_loaded?(Ecto) do
+  # This causes a warning because Ecto has already defined this Encoder. Overriding here
+  # because Ecto 2 removed the timezone portion of the iso8601 date string. This caused a
+  # regression in the API.
+  defimpl Poison.Encoder, for: Ecto.DateTime do
+    def encode(dt, _opts), do: <<?", (@for.to_iso8601(dt) <> "Z")::binary, ?">>
+  end
+end

--- a/test/hex_web/ecto_poison_datetime_override.exs
+++ b/test/hex_web/ecto_poison_datetime_override.exs
@@ -1,0 +1,9 @@
+defmodule HexWeb.EctoPoisonDateTimeOverrideTest do
+  use ExUnit.Case
+
+  test "Ecto.DateTime is encoded with a UTC time zone" do
+    datetime = Ecto.DateTime.from_erl({{2016, 5, 16}, {11, 3, 33}})
+
+    assert Poison.encode!(datetime) == "\"2016-05-16T11:03:33Z\""
+  end
+end


### PR DESCRIPTION
@ericmj @josevalim This fixes #340 