### PR TITLE
Remove dead code: AuditLog.build is no longer used

### DIFF
--- a/web/models/audit_log.ex
+++ b/web/models/audit_log.ex
@@ -8,10 +8,6 @@ defmodule HexWeb.AuditLog do
     timestamps(updated_at: false)
   end
 
-  def build(actor, action, params) do
-    %HexWeb.AuditLog{actor_id: actor.id, action: action, params: params}
-  end
-
   def create(%HexWeb.User{id: user_id}, action, params) do
     params = extract_params(action, params)
     %HexWeb.AuditLog{actor_id: user_id, action: action, params: params}


### PR DESCRIPTION
We use AuditLog.create instead. Looks like a leftover from ecto 1->2 migration.