### PR TITLE
Send email to multiple addresses at once

### DIFF
--- a/test/hex_web/throttle_test.exs
+++ b/test/hex_web/throttle_test.exs
@@ -15,23 +15,17 @@ defmodule HexWeb.ThrottleTest do
     # First time unit
     start = :erlang.monotonic_time(:milli_seconds)
 
-    Throttle.wait(context.pid)
+    Throttle.wait(context.pid, 1)
     assert diff(start) < 10
-    Throttle.wait(context.pid)
+    Throttle.wait(context.pid, 4)
     assert diff(start) < 10
-    Throttle.wait(context.pid)
-    assert diff(start) < 10
-    Throttle.wait(context.pid)
-    assert diff(start) < 10
-    Throttle.wait(context.pid)
-    assert diff(start) < 10
-    Throttle.wait(context.pid)
+    Throttle.wait(context.pid, 1)
     assert diff(start) > 90
 
     # Second time unit
     start = :erlang.monotonic_time(:milli_seconds)
 
-    Throttle.wait(context.pid)
+    Throttle.wait(context.pid, 1)
     assert diff(start) < 10
   end
 
@@ -39,7 +33,7 @@ defmodule HexWeb.ThrottleTest do
     # First time unit
     start = :erlang.monotonic_time(:milli_seconds)
 
-    Throttle.wait(context.pid)
+    Throttle.wait(context.pid, 1)
     assert diff(start) < 10
 
     :timer.sleep(110)
@@ -47,17 +41,9 @@ defmodule HexWeb.ThrottleTest do
     # Second time unit
     start = :erlang.monotonic_time(:milli_seconds)
 
-    Throttle.wait(context.pid)
+    Throttle.wait(context.pid, 5)
     assert diff(start) < 10
-    Throttle.wait(context.pid)
-    assert diff(start) < 10
-    Throttle.wait(context.pid)
-    assert diff(start) < 10
-    Throttle.wait(context.pid)
-    assert diff(start) < 10
-    Throttle.wait(context.pid)
-    assert diff(start) < 10
-    Throttle.wait(context.pid)
+    Throttle.wait(context.pid, 1)
     assert diff(start) > 90
   end
 
@@ -66,46 +52,46 @@ defmodule HexWeb.ThrottleTest do
     start = :erlang.monotonic_time(:milli_seconds)
 
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert diff(start) < 10
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert diff(start) < 10
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert diff(start) < 10
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert diff(start) < 10
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert diff(start) < 10
     end
 
     :timer.sleep(10)
 
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert_in_delta(90, 110, diff(start))
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert_in_delta(90, 110, diff(start))
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert_in_delta(90, 110, diff(start))
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert_in_delta(90, 110, diff(start))
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert_in_delta(90, 110, diff(start))
     end
 
@@ -113,23 +99,23 @@ defmodule HexWeb.ThrottleTest do
 
     # Third time unit
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert_in_delta(190, 210, diff(start))
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert_in_delta(190, 210, diff(start))
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert_in_delta(190, 210, diff(start))
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert_in_delta(190, 210, diff(start))
     end
     spawn_link fn ->
-      Throttle.wait(context.pid)
+      Throttle.wait(context.pid, 1)
       assert_in_delta(190, 210, diff(start))
     end
 

--- a/web/mailer.ex
+++ b/web/mailer.ex
@@ -3,9 +3,6 @@ defmodule HexWeb.Mailer do
     assigns = [layout: {HexWeb.EmailView, "layout.html"}] ++ assigns
     body    = Phoenix.View.render(HexWeb.EmailView, template, assigns)
 
-    HexWeb.Utils.task(fn ->
-      fun = fn email -> HexWeb.Email.send([email], title, body) end
-      HexWeb.Parallel.run(fun, emails)
-    end)
+    HexWeb.Email.send(emails, title, body)
   end
 end


### PR DESCRIPTION
@ericmj I got SES working for myself, and I finally found the bug that I originally introduced when I made sending email to multiple addresses: `To` header was incorrectly formatted with multiple emails. If it would still make sense to send emails to multiple recipients (e.g. to all package owners) this way, I think this patch should fix it. An advantage is to make less calls to SES and avoid parallelism (I left HexWeb.Parallel code for future use, currently it's unused). Otherwise please close :-)