### PR TITLE
Rename create to build in schemas

### DIFF
--- a/lib/hex_web/registry_builder.ex
+++ b/lib/hex_web/registry_builder.ex
@@ -21,7 +21,7 @@ defmodule HexWeb.RegistryBuilder do
   def rebuild do
     tmp      = Application.get_env(:hex_web, :tmp_dir)
     reg_file = Path.join(tmp, "registry.ets")
-    handle   = HexWeb.Registry.create
+    handle   = HexWeb.Registry.build
                |> HexWeb.Repo.insert!
 
     rebuild(handle, reg_file)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -4,7 +4,7 @@ defmodule SampleData do
   end
 
   def create_user(username, email, password) do
-    HexWeb.User.create(%{username: username, email: email, password: password}, true)
+    HexWeb.User.build(%{username: username, email: email, password: password}, true)
     |> HexWeb.Repo.insert!
   end
 
@@ -34,7 +34,7 @@ HexWeb.Repo.transaction(fn ->
 
   unless eric == nil do
     decimal =
-      Package.create(eric, %{
+      Package.build(eric, %{
         "name" => "decimal",
         "meta" => %{
           "maintainers" => ["Eric Meadows-Jönsson"],
@@ -44,12 +44,12 @@ HexWeb.Repo.transaction(fn ->
           "description" => "Arbitrary precision decimal arithmetic for Elixir"}})
       |> HexWeb.Repo.insert!
 
-    Release.create(decimal, %{"version" => "0.0.1", "app" => "decimal", "meta" => %{"app" => "decimal", "build_tools" =>  ["mix"]}}, SampleData.checksum("decimal 0.0.1")) |> HexWeb.Repo.insert!
-    Release.create(decimal, %{"version" => "0.0.2", "app" => "decimal", "meta" => %{"app" => "decimal", "build_tools" =>  ["mix"]}}, SampleData.checksum("decimal 0.0.2")) |> HexWeb.Repo.insert!
-    Release.create(decimal, %{"version" => "0.1.0", "app" => "decimal", "meta" => %{"app" => "decimal", "build_tools" =>  ["mix"]}}, SampleData.checksum("decimal 0.1.0")) |> HexWeb.Repo.insert!
+    Release.build(decimal, %{"version" => "0.0.1", "app" => "decimal", "meta" => %{"app" => "decimal", "build_tools" =>  ["mix"]}}, SampleData.checksum("decimal 0.0.1")) |> HexWeb.Repo.insert!
+    Release.build(decimal, %{"version" => "0.0.2", "app" => "decimal", "meta" => %{"app" => "decimal", "build_tools" =>  ["mix"]}}, SampleData.checksum("decimal 0.0.2")) |> HexWeb.Repo.insert!
+    Release.build(decimal, %{"version" => "0.1.0", "app" => "decimal", "meta" => %{"app" => "decimal", "build_tools" =>  ["mix"]}}, SampleData.checksum("decimal 0.1.0")) |> HexWeb.Repo.insert!
 
     postgrex =
-      Package.create(eric, %{
+      Package.build(eric, %{
         "name" => "postgrex",
         "meta" => %{
           "maintainers" => ["Eric Meadows-Jönsson", "José Valim"],
@@ -58,16 +58,16 @@ HexWeb.Repo.transaction(fn ->
           "description" => lorem}})
       |> HexWeb.Repo.insert!
 
-    Release.create(postgrex, %{"version" => "0.0.1", "app" => "postgrex", "meta" => %{"app" => "postgrex", "build_tools" => ["mix"]}}, SampleData.checksum("postgrex 0.0.1")) |> HexWeb.Repo.insert!
+    Release.build(postgrex, %{"version" => "0.0.1", "app" => "postgrex", "meta" => %{"app" => "postgrex", "build_tools" => ["mix"]}}, SampleData.checksum("postgrex 0.0.1")) |> HexWeb.Repo.insert!
     reqs = [%{"name" => "decimal", "app" => "decimal", "requirement" => "~> 0.0.1", "optional" => false}]
-    Release.create(postgrex, %{"version" => "0.0.2", "app" => "postgrex", "requirements" => reqs, "meta" => %{"app" => "postgrex", "build_tools" => ["mix"]}}, SampleData.checksum("postgrex 0.0.2")) |> HexWeb.Repo.insert!
+    Release.build(postgrex, %{"version" => "0.0.2", "app" => "postgrex", "requirements" => reqs, "meta" => %{"app" => "postgrex", "build_tools" => ["mix"]}}, SampleData.checksum("postgrex 0.0.2")) |> HexWeb.Repo.insert!
     reqs = [%{"name" => "decimal", "app" => "decimal", "requirement" => "0.1.0", "optional" => false}]
-    Release.create(postgrex, %{"version" => "0.1.0", "app" => "postgrex", "requirements" => reqs, "meta" => %{"app" => "postgrex", "build_tools" => ["mix"]}}, SampleData.checksum("postgrex 0.1.0")) |> HexWeb.Repo.insert!
+    Release.build(postgrex, %{"version" => "0.1.0", "app" => "postgrex", "requirements" => reqs, "meta" => %{"app" => "postgrex", "build_tools" => ["mix"]}}, SampleData.checksum("postgrex 0.1.0")) |> HexWeb.Repo.insert!
   end
 
   unless jose == nil do
     ecto =
-      Package.create(jose, %{
+      Package.build(jose, %{
         "name" => "ecto",
         "meta" => %{
           "maintainers" => ["Eric Meadows-Jönsson", "José Valim"],
@@ -76,19 +76,19 @@ HexWeb.Repo.transaction(fn ->
           "description" => lorem}})
       |> HexWeb.Repo.insert!
 
-    Release.create(ecto, %{"version" => "0.0.1", "app" => "ecto", "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.0.1")) |> HexWeb.Repo.insert!
+    Release.build(ecto, %{"version" => "0.0.1", "app" => "ecto", "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.0.1")) |> HexWeb.Repo.insert!
     reqs = [%{"name" => "postgrex", "app" => "postgrex", "requirement" => "~> 0.0.1", "optional" => false}]
-    Release.create(ecto, %{"version" => "0.0.2", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.0.2")) |> HexWeb.Repo.insert!
+    Release.build(ecto, %{"version" => "0.0.2", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.0.2")) |> HexWeb.Repo.insert!
     reqs = [%{"name" => "postgrex", "app" => "postgrex", "requirement" => "~> 0.0.2", "optional" => false}]
-    Release.create(ecto, %{"version" => "0.1.0", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.1.0")) |> HexWeb.Repo.insert!
+    Release.build(ecto, %{"version" => "0.1.0", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.1.0")) |> HexWeb.Repo.insert!
     reqs = [%{"name" => "postgrex", "app" => "postgrex", "requirement" => "~> 0.1.0", "optional" => false}]
-    Release.create(ecto, %{"version" => "0.1.1", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.1.1")) |> HexWeb.Repo.insert!
+    Release.build(ecto, %{"version" => "0.1.1", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.1.1")) |> HexWeb.Repo.insert!
     reqs = [%{"name" => "postgrex", "app" => "postgrex", "requirement" => "== 0.1.0", "optional" => false}, %{"name" => "decimal", "app" => "decimal", "requirement" => "0.1.0", "optional" => false}]
-    Release.create(ecto, %{"version" => "0.1.2", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.1.2")) |> HexWeb.Repo.insert!
+    Release.build(ecto, %{"version" => "0.1.2", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.1.2")) |> HexWeb.Repo.insert!
     reqs = [%{"name" => "postgrex", "app" => "postgrex", "requirement" => "0.1.0", "optional" => false}, %{"name" => "decimal", "app" => "decimal", "requirement" => "0.1.0", "optional" => false}]
-    Release.create(ecto, %{"version" => "0.1.3", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.1.3")) |> HexWeb.Repo.insert!
+    Release.build(ecto, %{"version" => "0.1.3", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.1.3")) |> HexWeb.Repo.insert!
     reqs = [%{"name" => "postgrex", "app" => "postgrex", "requirement" => "~> 0.1.0", "optional" => false}, %{"name" => "decimal", "app" => "decimal", "requirement" => "~> 0.1.0", "optional" => false}]
-    rel = Release.create(ecto, %{"version" => "0.2.0", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.2.0")) |> HexWeb.Repo.insert!
+    rel = Release.build(ecto, %{"version" => "0.2.0", "app" => "ecto", "requirements" => reqs, "meta" => %{"app" => "ecto", "build_tools" => ["mix"]}}, SampleData.checksum("ecto 0.2.0")) |> HexWeb.Repo.insert!
 
     {:ok, yesterday} = Ecto.Type.load(Ecto.Date, HexWeb.Utils.yesterday)
     %Download{release_id: rel.id, downloads: 42, day: yesterday}
@@ -98,7 +98,7 @@ HexWeb.Repo.transaction(fn ->
   unless joe == nil do
     Enum.each(1..100, fn(index) ->
       ups =
-        Package.create(joe, %{
+        Package.build(joe, %{
           "name" => "ups_" <> to_string(index),
           "meta" => %{
             "maintainers" => ["Joe Somebody"],
@@ -107,9 +107,9 @@ HexWeb.Repo.transaction(fn ->
             "description" => lorem}})
         |> HexWeb.Repo.insert!
 
-      rel1 = Release.create(ups, %{"version" => "0.0.1", "app" => "ups", "meta" => %{"app" => "ups", "build_tools" => ["mix"]}}, SampleData.checksum("ups 0.0.1")) |> HexWeb.Repo.insert!
+      rel1 = Release.build(ups, %{"version" => "0.0.1", "app" => "ups", "meta" => %{"app" => "ups", "build_tools" => ["mix"]}}, SampleData.checksum("ups 0.0.1")) |> HexWeb.Repo.insert!
       reqs = [%{"name" => "postgrex", "app" => "postgrex", "requirement" => "~> 0.1.0", "optional" => false}, %{"name" => "decimal", "app" => "postgrex", "requirement" => "~> 0.1.0", "optional" => false}]
-      rel2 = Release.create(ups, %{"version" => "0.2.0", "app" => "ups", "requirements" => reqs, "meta" => %{"app" => "ups", "build_tools" => ["mix"]}}, SampleData.checksum("ups 0.2.0")) |> HexWeb.Repo.insert!
+      rel2 = Release.build(ups, %{"version" => "0.2.0", "app" => "ups", "requirements" => reqs, "meta" => %{"app" => "ups", "build_tools" => ["mix"]}}, SampleData.checksum("ups 0.2.0")) |> HexWeb.Repo.insert!
 
       {:ok, last_month} = Ecto.Type.load(Ecto.Date, SampleData.last_month)
       %Download{release_id: rel1.id, downloads: div(index, 2), day: last_month}

--- a/scripts/add_install.exs
+++ b/scripts/add_install.exs
@@ -5,7 +5,7 @@ case System.argv do
     IO.puts "Hex:     " <> hex
     IO.puts "Elixirs: " <> Enum.join(elixirs, ", ")
 
-    HexWeb.Install.create(hex, elixirs) |> HexWeb.Repo.insert
+    HexWeb.Install.build(hex, elixirs) |> HexWeb.Repo.insert
 
   _ ->
     :ok

--- a/scripts/add_owner.exs
+++ b/scripts/add_owner.exs
@@ -13,4 +13,4 @@ unless user do
   System.halt(1)
 end
 
-HexWeb.Package.create_owner(package, user) |> HexWeb.Repo.insert!
+HexWeb.Package.build_owner(package, user) |> HexWeb.Repo.insert!

--- a/test/controllers/api/docs_controller_test.exs
+++ b/test/controllers/api/docs_controller_test.exs
@@ -6,7 +6,7 @@ defmodule HexWeb.API.DocsControllerTest do
   alias HexWeb.Release
 
   setup do
-    User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
+    User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
     |> HexWeb.Repo.insert!
     :ok
   end
@@ -14,9 +14,9 @@ defmodule HexWeb.API.DocsControllerTest do
   @tag :integration
   test "release docs" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    phoenix = Package.create(user, pkg_meta(%{name: "phoenix", description: "Web framework"})) |> HexWeb.Repo.insert!
-    Release.create(phoenix, rel_meta(%{version: "0.0.1", app: "phoenix"}), "") |> HexWeb.Repo.insert!
-    Release.create(phoenix, rel_meta(%{version: "0.0.2", app: "phoenix"}), "") |> HexWeb.Repo.insert!
+    phoenix = Package.build(user, pkg_meta(%{name: "phoenix", description: "Web framework"})) |> HexWeb.Repo.insert!
+    Release.build(phoenix, rel_meta(%{version: "0.0.1", app: "phoenix"}), "") |> HexWeb.Repo.insert!
+    Release.build(phoenix, rel_meta(%{version: "0.0.2", app: "phoenix"}), "") |> HexWeb.Repo.insert!
 
     body = create_tarball([{'index.html', "HEYO"}])
     conn = conn()
@@ -62,10 +62,10 @@ defmodule HexWeb.API.DocsControllerTest do
   @tag :integration
   test "release beta docs" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    plug = Package.create(user, pkg_meta(%{name: "plug", description: "Web framework"})) |> HexWeb.Repo.insert!
-    Release.create(plug, rel_meta(%{version: "0.0.1-beta.1", app: "plug"}), "") |> HexWeb.Repo.insert!
-    Release.create(plug, rel_meta(%{version: "0.5.0", app: "plug"}), "") |> HexWeb.Repo.insert!
-    Release.create(plug, rel_meta(%{version: "1.0.0-beta.1", app: "plug"}), "") |> HexWeb.Repo.insert!
+    plug = Package.build(user, pkg_meta(%{name: "plug", description: "Web framework"})) |> HexWeb.Repo.insert!
+    Release.build(plug, rel_meta(%{version: "0.0.1-beta.1", app: "plug"}), "") |> HexWeb.Repo.insert!
+    Release.build(plug, rel_meta(%{version: "0.5.0", app: "plug"}), "") |> HexWeb.Repo.insert!
+    Release.build(plug, rel_meta(%{version: "1.0.0-beta.1", app: "plug"}), "") |> HexWeb.Repo.insert!
 
     body = create_tarball([{'index.html', "plug v0.0.1-beta.1"}])
     conn = conn()
@@ -108,8 +108,8 @@ defmodule HexWeb.API.DocsControllerTest do
 
   test "delete release with docs" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    ecto = Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
-    Release.create(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "") |> HexWeb.Repo.insert!
+    ecto = Package.build(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
+    Release.build(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "") |> HexWeb.Repo.insert!
 
     body = create_tarball([{'index.html', "HEYO"}])
     conn = conn()
@@ -140,8 +140,8 @@ defmodule HexWeb.API.DocsControllerTest do
   @tag :integration
   test "delete docs" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    ecto = Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
-    Release.create(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "") |> HexWeb.Repo.insert!
+    ecto = Package.build(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
+    Release.build(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "") |> HexWeb.Repo.insert!
 
     body = create_tarball([{'index.html', "HEYO"}])
     conn = conn()
@@ -177,8 +177,8 @@ defmodule HexWeb.API.DocsControllerTest do
   @tag :integration
   test "dont allow version directories in docs" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    ecto = Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
-    Release.create(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "") |> HexWeb.Repo.insert!
+    ecto = Package.build(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
+    Release.build(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "") |> HexWeb.Repo.insert!
 
     body = create_tarball([{'1.2.3', "HEYO"}])
     conn = conn()

--- a/test/controllers/api/key_controller_test.exs
+++ b/test/controllers/api/key_controller_test.exs
@@ -5,9 +5,9 @@ defmodule HexWeb.API.KeyControllerTest do
   alias HexWeb.User
 
   setup do
-    User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
+    User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
     |> HexWeb.Repo.insert!
-    User.create(%{username: "other", email: "other@mail.com", password: "other"}, true)
+    User.build(%{username: "other", email: "other@mail.com", password: "other"}, true)
     |> HexWeb.Repo.insert!
     :ok
   end
@@ -32,7 +32,7 @@ defmodule HexWeb.API.KeyControllerTest do
 
   test "get key" do
     HexWeb.Repo.get_by!(User, username: "eric")
-    |> Key.create(%{name: "macbook"})
+    |> Key.build(%{name: "macbook"})
     |> HexWeb.Repo.insert!
 
     conn = conn()
@@ -48,8 +48,8 @@ defmodule HexWeb.API.KeyControllerTest do
 
   test "all keys" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    Key.create(user, %{name: "macbook"}) |> HexWeb.Repo.insert!
-    key = Key.create(user, %{name: "computer"}) |> HexWeb.Repo.insert!
+    Key.build(user, %{name: "macbook"}) |> HexWeb.Repo.insert!
+    key = Key.build(user, %{name: "computer"}) |> HexWeb.Repo.insert!
 
     conn = conn()
            |> put_req_header("authorization", key.user_secret)
@@ -66,8 +66,8 @@ defmodule HexWeb.API.KeyControllerTest do
 
   test "delete key" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    Key.create(user, %{name: "macbook"}) |> HexWeb.Repo.insert!
-    Key.create(user, %{name: "computer"}) |> HexWeb.Repo.insert!
+    Key.build(user, %{name: "macbook"}) |> HexWeb.Repo.insert!
+    Key.build(user, %{name: "computer"}) |> HexWeb.Repo.insert!
 
     conn = conn()
            |> put_req_header("authorization", key_for("eric"))
@@ -85,7 +85,7 @@ defmodule HexWeb.API.KeyControllerTest do
 
   test "key authorizes" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    key = Key.create(user, %{name: "macbook"}) |> HexWeb.Repo.insert!
+    key = Key.build(user, %{name: "macbook"}) |> HexWeb.Repo.insert!
 
     conn = conn()
            |> put_req_header("authorization", key.user_secret)

--- a/test/controllers/api/owner_controller_test.exs
+++ b/test/controllers/api/owner_controller_test.exs
@@ -6,12 +6,12 @@ defmodule HexWeb.API.OwnerControllerTest do
   alias HexWeb.Release
 
   setup do
-    user = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
-    User.create(%{username: "jose", email: "jose@mail.com", password: "jose"}, true) |> HexWeb.Repo.insert!
-    User.create(%{username: "other", email: "other@mail.com", password: "other"}, true) |> HexWeb.Repo.insert!
-    pkg = Package.create(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal arithmetic for Elixir."})) |> HexWeb.Repo.insert!
-    Package.create(user, pkg_meta(%{name: "postgrex", description: "Postgrex is awesome"})) |> HexWeb.Repo.insert!
-    Release.create(pkg, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
+    user = User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
+    User.build(%{username: "jose", email: "jose@mail.com", password: "jose"}, true) |> HexWeb.Repo.insert!
+    User.build(%{username: "other", email: "other@mail.com", password: "other"}, true) |> HexWeb.Repo.insert!
+    pkg = Package.build(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal arithmetic for Elixir."})) |> HexWeb.Repo.insert!
+    Package.build(user, pkg_meta(%{name: "postgrex", description: "Postgrex is awesome"})) |> HexWeb.Repo.insert!
+    Release.build(pkg, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
     :ok
   end
 
@@ -26,7 +26,7 @@ defmodule HexWeb.API.OwnerControllerTest do
 
     package = HexWeb.Repo.get_by!(Package, name: "postgrex")
     user = HexWeb.Repo.get_by!(User, username: "jose")
-    Package.create_owner(package, user) |> HexWeb.Repo.insert!
+    Package.build_owner(package, user) |> HexWeb.Repo.insert!
 
     conn = conn()
            |> put_req_header("authorization", key_for("eric"))
@@ -118,7 +118,7 @@ defmodule HexWeb.API.OwnerControllerTest do
     eric = HexWeb.Repo.get_by!(User, username: "eric")
     jose = HexWeb.Repo.get_by!(User, username: "jose")
     package = HexWeb.Repo.get_by!(Package, name: "postgrex")
-    Package.create_owner(package, jose) |> HexWeb.Repo.insert!
+    Package.build_owner(package, jose) |> HexWeb.Repo.insert!
 
     conn = conn()
            |> put_req_header("authorization", key_for(eric))

--- a/test/controllers/api/package_controller_test.exs
+++ b/test/controllers/api/package_controller_test.exs
@@ -6,10 +6,10 @@ defmodule HexWeb.API.PackageControllerTest do
   alias HexWeb.Release
 
   setup do
-    user       = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
-    pkg = Package.create(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal arithmetic for Elixir."})) |> HexWeb.Repo.insert!
-    Package.create(user, pkg_meta(%{name: "postgrex", description: "Postgrex is awesome"})) |> HexWeb.Repo.insert!
-    Release.create(pkg, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
+    user       = User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
+    pkg = Package.build(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal arithmetic for Elixir."})) |> HexWeb.Repo.insert!
+    Package.build(user, pkg_meta(%{name: "postgrex", description: "Postgrex is awesome"})) |> HexWeb.Repo.insert!
+    Release.build(pkg, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
     :ok
   end
 

--- a/test/controllers/api/release_controller_test.exs
+++ b/test/controllers/api/release_controller_test.exs
@@ -7,9 +7,9 @@ defmodule HexWeb.API.ReleaseControllerTest do
   alias HexWeb.RegistryBuilder
 
   setup do
-    user = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
-    pkg = Package.create(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal aritmetic for Elixir."})) |> HexWeb.Repo.insert!
-    Release.create(pkg, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
+    user = User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
+    pkg = Package.build(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal aritmetic for Elixir."})) |> HexWeb.Repo.insert!
+    Release.build(pkg, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
     :ok
   end
 
@@ -37,7 +37,7 @@ defmodule HexWeb.API.ReleaseControllerTest do
 
   test "update package" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
+    Package.build(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
 
     meta = %{name: "ecto", version: "1.0.0", description: "awesomeness"}
     conn = conn()
@@ -65,7 +65,7 @@ defmodule HexWeb.API.ReleaseControllerTest do
 
   test "update package authorizes" do
     HexWeb.Repo.get_by!(User, username: "eric")
-    |> Package.create(pkg_meta(%{name: "ecto", description: "DSL"}))
+    |> Package.build(pkg_meta(%{name: "ecto", description: "DSL"}))
 
     meta = %{name: "ecto", version: "1.0.0", description: "Domain-specific language."}
     conn = conn()

--- a/test/controllers/api/user_controller_test.exs
+++ b/test/controllers/api/user_controller_test.exs
@@ -4,7 +4,7 @@ defmodule HexWeb.API.UserControllerTest do
   alias HexWeb.User
 
   setup do
-    User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
+    User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
     |> HexWeb.Repo.insert!
     :ok
   end

--- a/test/controllers/installs_controller_test.exs
+++ b/test/controllers/installs_controller_test.exs
@@ -23,7 +23,7 @@ defmodule HexWeb.InstallsControllerTest do
                 {"0.2.1", ["1.0.0"]}]
 
     Enum.each(versions, fn {hex, elixirs} ->
-      HexWeb.Install.create(hex, elixirs)
+      HexWeb.Install.build(hex, elixirs)
       |> HexWeb.Repo.insert
     end)
 

--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -5,12 +5,12 @@ defmodule HexWeb.PageControllerTest do
   alias HexWeb.Release
 
   defp create_user(username, email, password) do
-    HexWeb.User.create(%{username: username, email: email, password: password}, true)
+    HexWeb.User.build(%{username: username, email: email, password: password}, true)
     |> HexWeb.Repo.insert!
   end
 
   defp release_create(package, version, app, requirements, checksum, inserted_at) do
-    release = Release.create(package, rel_meta(%{version: version, app: app, requirements: requirements}), checksum)
+    release = Release.build(package, rel_meta(%{version: version, app: app, requirements: requirements}), checksum)
               |> HexWeb.Repo.insert!
     Ecto.Changeset.change(release, inserted_at: inserted_at)
     |> HexWeb.Repo.update!
@@ -23,9 +23,9 @@ defmodule HexWeb.PageControllerTest do
 
     eric = create_user("eric", "eric@example.com", "eric")
 
-    foo = Package.create(eric, %{name: "foo", inserted_at: first_date, updated_at: first_date, meta: %{description: "foo", licenses: ["Apache"]}}) |> HexWeb.Repo.insert!
-    bar = Package.create(eric, %{name: "bar", inserted_at: second_date, updated_at: second_date, meta: %{description: "bar", licenses: ["Apache"]}}) |> HexWeb.Repo.insert!
-    other = Package.create(eric, %{name: "other", inserted_at: last_date, updated_at: last_date, meta: %{description: "other", licenses: ["Apache"]}}) |> HexWeb.Repo.insert!
+    foo = Package.build(eric, %{name: "foo", inserted_at: first_date, updated_at: first_date, meta: %{description: "foo", licenses: ["Apache"]}}) |> HexWeb.Repo.insert!
+    bar = Package.build(eric, %{name: "bar", inserted_at: second_date, updated_at: second_date, meta: %{description: "bar", licenses: ["Apache"]}}) |> HexWeb.Repo.insert!
+    other = Package.build(eric, %{name: "other", inserted_at: last_date, updated_at: last_date, meta: %{description: "other", licenses: ["Apache"]}}) |> HexWeb.Repo.insert!
 
     release_create(foo, "0.0.1", "foo", [], "", Ecto.DateTime.from_erl({{2014, 5, 3}, {10, 11, 1}}))
     release_create(foo, "0.0.2", "foo", [], "", Ecto.DateTime.from_erl({{2014, 5, 3}, {10, 11, 2}}))

--- a/test/controllers/password_controller_test.exs
+++ b/test/controllers/password_controller_test.exs
@@ -7,7 +7,7 @@ defmodule HexWeb.PasswordControllerTest do
   test "reset user password" do
     # create user and test with current password
     user = 
-      User.create(%{username: "eric", email: "eric@mail.com", password: "hunter42"}, true)
+      User.build(%{username: "eric", email: "eric@mail.com", password: "hunter42"}, true)
       |> HexWeb.Repo.insert!
     
     assert {:ok, %User{username: "eric"}} = Auth.password_auth("eric", "hunter42")

--- a/test/controllers/sitemap_controller_test.exs
+++ b/test/controllers/sitemap_controller_test.exs
@@ -5,8 +5,8 @@ defmodule HexWeb.SitemapControllerTest do
   alias HexWeb.User
 
   setup do
-    user = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
-    package = Package.create(user, pkg_meta(%{name: "postgrex", description: "Postgrex is awesome"})) |> HexWeb.Repo.insert!
+    user = User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
+    package = Package.build(user, pkg_meta(%{name: "postgrex", description: "Postgrex is awesome"})) |> HexWeb.Repo.insert!
     {:ok, date} = Ecto.DateTime.cast("2014-04-17T14:00:00Z")
     package
     |> Ecto.Changeset.change(updated_at: date)

--- a/test/controllers/test_controller_test.exs
+++ b/test/controllers/test_controller_test.exs
@@ -7,10 +7,10 @@ defmodule HexWeb.TestControllerTest do
   alias HexWeb.RegistryBuilder
 
   setup do
-    user       = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
-    Package.create(user, pkg_meta(%{name: "postgrex", description: "PostgreSQL driver for Elixir."})) |> HexWeb.Repo.insert!
-    pkg = Package.create(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal arithmetic for Elixir."})) |> HexWeb.Repo.insert!
-    Release.create(pkg, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
+    user = User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
+    Package.build(user, pkg_meta(%{name: "postgrex", description: "PostgreSQL driver for Elixir."})) |> HexWeb.Repo.insert!
+    pkg = Package.build(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal arithmetic for Elixir."})) |> HexWeb.Repo.insert!
+    Release.build(pkg, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
     :ok
   end
 

--- a/test/hex_web/registry_builder_test.exs
+++ b/test/hex_web/registry_builder_test.exs
@@ -11,12 +11,12 @@ defmodule HexWeb.RegistryBuilderTest do
   @endpoint HexWeb.Endpoint
 
   setup do
-    user = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
-    Package.create(user, pkg_meta(%{name: "postgrex", description: "PostgreSQL driver for Elixir."})) |> HexWeb.Repo.insert!
-    Package.create(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal arithmetic for Elixir."})) |> HexWeb.Repo.insert!
-    Package.create(user, pkg_meta(%{name: "ex_doc", description: "ExDoc"})) |> HexWeb.Repo.insert!
-    Install.create("0.0.1", ["0.13.0-dev"]) |> HexWeb.Repo.insert!
-    Install.create("0.1.0", ["0.13.1-dev", "0.13.1"]) |> HexWeb.Repo.insert!
+    user = User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
+    Package.build(user, pkg_meta(%{name: "postgrex", description: "PostgreSQL driver for Elixir."})) |> HexWeb.Repo.insert!
+    Package.build(user, pkg_meta(%{name: "decimal", description: "Arbitrary precision decimal arithmetic for Elixir."})) |> HexWeb.Repo.insert!
+    Package.build(user, pkg_meta(%{name: "ex_doc", description: "ExDoc"})) |> HexWeb.Repo.insert!
+    Install.build("0.0.1", ["0.13.0-dev"]) |> HexWeb.Repo.insert!
+    Install.build("0.1.0", ["0.13.1-dev", "0.13.1"]) |> HexWeb.Repo.insert!
     :ok
   end
 
@@ -34,14 +34,14 @@ defmodule HexWeb.RegistryBuilderTest do
     postgrex = HexWeb.Repo.get_by!(Package, name: "postgrex")
     decimal = HexWeb.Repo.get_by!(Package, name: "decimal")
 
-    Release.create(ex_doc, rel_meta(%{version: "0.0.1", app: "ex_doc"}), "") |> HexWeb.Repo.insert!
-    Release.create(decimal, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
+    Release.build(ex_doc, rel_meta(%{version: "0.0.1", app: "ex_doc"}), "") |> HexWeb.Repo.insert!
+    Release.build(decimal, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
     reqs = [%{name: "ex_doc", app: "ex_doc", requirement: "0.0.1", optional: false}]
-    Release.create(decimal, rel_meta(%{version: "0.0.2", app: "decimal", requirements: reqs}), "") |> HexWeb.Repo.insert!
+    Release.build(decimal, rel_meta(%{version: "0.0.2", app: "decimal", requirements: reqs}), "") |> HexWeb.Repo.insert!
     reqs = [%{name: "decimal", app: "decimal", requirement: "~> 0.0.1", optional: false},
             %{name: "ex_doc", app: "ex_doc", requirement: "0.0.1", optional: false}]
     meta = rel_meta(%{requirements: reqs, app: "postgrex", version: "0.0.2"})
-    Release.create(postgrex, meta, "") |> HexWeb.Repo.insert!
+    Release.build(postgrex, meta, "") |> HexWeb.Repo.insert!
   end
 
   test "registry is versioned" do
@@ -109,9 +109,9 @@ defmodule HexWeb.RegistryBuilderTest do
   #   postgrex = HexWeb.Repo.get_by(Package, name: "postgrex")
   #   decimal = HexWeb.Repo.get_by(Package, name: "decimal")
 
-  #   Release.create(decimal, %{version: "0.0.1", app: "decimal"}, "")
-  #   Release.create(decimal, %{version: "0.0.2", app: "decimal", requirements: %{ex_doc: "0.0.0"}}, "")
-  #   Release.create(postgrex, %{version: "0.0.2", app: "postgrex", requirements: %{decimal: "~> 0.0.1", ex_doc: "0.1.0"}}, "")
+  #   Release.build(decimal, %{version: "0.0.1", app: "decimal"}, "")
+  #   Release.build(decimal, %{version: "0.0.2", app: "decimal", requirements: %{ex_doc: "0.0.0"}}, "")
+  #   Release.build(postgrex, %{version: "0.0.2", app: "postgrex", requirements: %{decimal: "~> 0.0.1", ex_doc: "0.1.0"}}, "")
 
   #   pid = self
 

--- a/test/hex_web/stats_job_test.exs
+++ b/test/hex_web/stats_job_test.exs
@@ -6,19 +6,19 @@ defmodule HexWeb.StatsJobTest do
   alias HexWeb.Release
 
   setup do
-    user = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
+    user = User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
 
-    foo   = Package.create(user, pkg_meta(%{name: "foo", description: "Foo"})) |> HexWeb.Repo.insert!
-    bar   = Package.create(user, pkg_meta(%{name: "bar", description: "Bar"})) |> HexWeb.Repo.insert!
-    other = Package.create(user, pkg_meta(%{name: "other", description: "Other"})) |> HexWeb.Repo.insert!
+    foo   = Package.build(user, pkg_meta(%{name: "foo", description: "Foo"})) |> HexWeb.Repo.insert!
+    bar   = Package.build(user, pkg_meta(%{name: "bar", description: "Bar"})) |> HexWeb.Repo.insert!
+    other = Package.build(user, pkg_meta(%{name: "other", description: "Other"})) |> HexWeb.Repo.insert!
 
-    Release.create(foo, rel_meta(%{version: "0.0.1", app: "foo"}), "") |> HexWeb.Repo.insert!
-    Release.create(foo, rel_meta(%{version: "0.0.2", app: "foo"}), "") |> HexWeb.Repo.insert!
-    Release.create(foo, rel_meta(%{version: "0.1.0", app: "foo"}), "") |> HexWeb.Repo.insert!
-    Release.create(bar, rel_meta(%{version: "0.0.1", app: "bar"}), "") |> HexWeb.Repo.insert!
-    Release.create(bar, rel_meta(%{version: "0.0.2", app: "bar"}), "") |> HexWeb.Repo.insert!
-    Release.create(bar, rel_meta(%{version: "0.0.3-rc.1", app: "bar"}), "") |> HexWeb.Repo.insert!
-    Release.create(other, rel_meta(%{version: "0.0.1", app: "other"}), "") |> HexWeb.Repo.insert!
+    Release.build(foo, rel_meta(%{version: "0.0.1", app: "foo"}), "") |> HexWeb.Repo.insert!
+    Release.build(foo, rel_meta(%{version: "0.0.2", app: "foo"}), "") |> HexWeb.Repo.insert!
+    Release.build(foo, rel_meta(%{version: "0.1.0", app: "foo"}), "") |> HexWeb.Repo.insert!
+    Release.build(bar, rel_meta(%{version: "0.0.1", app: "bar"}), "") |> HexWeb.Repo.insert!
+    Release.build(bar, rel_meta(%{version: "0.0.2", app: "bar"}), "") |> HexWeb.Repo.insert!
+    Release.build(bar, rel_meta(%{version: "0.0.3-rc.1", app: "bar"}), "") |> HexWeb.Repo.insert!
+    Release.build(other, rel_meta(%{version: "0.0.1", app: "other"}), "") |> HexWeb.Repo.insert!
 
     :ok
   end

--- a/test/models/audit_log_test.exs
+++ b/test/models/audit_log_test.exs
@@ -1,12 +1,12 @@
 defmodule HexWeb.AuditLogTest do
   use HexWeb.ModelCase
 
-  test "create" do
+  test "build" do
     actor = %HexWeb.User{id: 1}
     package = %HexWeb.Package{id: 2, name: "ecto", meta: %HexWeb.PackageMetadata{description: "some description"}}
     user = %HexWeb.User{id: 3, username: "eric", email: "eric@mail.com", confirmed: true}
 
-    assert HexWeb.AuditLog.create(actor, "owner.add", {package, user}) ==
+    assert HexWeb.AuditLog.build(actor, "owner.add", {package, user}) ==
       %HexWeb.AuditLog{
         actor_id: 1,
         action: "owner.add",

--- a/test/models/key_test.exs
+++ b/test/models/key_test.exs
@@ -5,30 +5,30 @@ defmodule HexWeb.KeyTest do
   alias HexWeb.Key
 
   setup do
-    User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
+    User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true)
     |> HexWeb.Repo.insert!
     :ok
   end
 
   test "create key and get" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    Key.create(user, %{name: "computer"}) |> HexWeb.Repo.insert!
+    Key.build(user, %{name: "computer"}) |> HexWeb.Repo.insert!
     assert HexWeb.Repo.one!(Key.get("computer", user)).user_id == user.id
   end
 
   test "create unique key name" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    assert %Key{name: "computer"}   = Key.create(user, %{name: "computer"}) |> HexWeb.Repo.insert!
-    assert %Key{name: "computer-2"} = Key.create(user, %{name: "computer"}) |> HexWeb.Repo.insert!
+    assert %Key{name: "computer"}   = Key.build(user, %{name: "computer"}) |> HexWeb.Repo.insert!
+    assert %Key{name: "computer-2"} = Key.build(user, %{name: "computer"}) |> HexWeb.Repo.insert!
   end
 
   test "all user keys" do
     eric = HexWeb.Repo.get_by!(User, username: "eric")
-    jose = User.create(%{username: "jose", email: "jose@mail.com", password: "jose"}, true) |> HexWeb.Repo.insert!
+    jose = User.build(%{username: "jose", email: "jose@mail.com", password: "jose"}, true) |> HexWeb.Repo.insert!
 
-    assert %Key{name: "computer"} = Key.create(eric, %{name: "computer"}) |> HexWeb.Repo.insert!
-    assert %Key{name: "macbook"}  = Key.create(eric, %{name: "macbook"}) |> HexWeb.Repo.insert!
-    assert %Key{name: "macbook"}  = Key.create(jose, %{name: "macbook"}) |> HexWeb.Repo.insert!
+    assert %Key{name: "computer"} = Key.build(eric, %{name: "computer"}) |> HexWeb.Repo.insert!
+    assert %Key{name: "macbook"}  = Key.build(eric, %{name: "macbook"}) |> HexWeb.Repo.insert!
+    assert %Key{name: "macbook"}  = Key.build(jose, %{name: "macbook"}) |> HexWeb.Repo.insert!
 
     assert (Key.all(eric) |> HexWeb.Repo.all |> length) == 2
     assert (Key.all(jose) |> HexWeb.Repo.all |> length) == 1
@@ -36,8 +36,8 @@ defmodule HexWeb.KeyTest do
 
   test "delete keys" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    Key.create(user, %{name: "computer"}) |> HexWeb.Repo.insert!
-    Key.create(user, %{name: "macbook"})  |> HexWeb.Repo.insert!
+    Key.build(user, %{name: "computer"}) |> HexWeb.Repo.insert!
+    Key.build(user, %{name: "macbook"})  |> HexWeb.Repo.insert!
 
     Key.get("computer", user) |> HexWeb.Repo.delete_all
     assert [%Key{name: "macbook"}] = Key.all(user) |> HexWeb.Repo.all

--- a/test/models/package_test.exs
+++ b/test/models/package_test.exs
@@ -5,7 +5,7 @@ defmodule HexWeb.PackageTest do
   alias HexWeb.Package
 
   setup do
-    User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
+    User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
     :ok
   end
 
@@ -13,14 +13,14 @@ defmodule HexWeb.PackageTest do
     user = HexWeb.Repo.get_by!(User, username: "eric")
     user_id = user.id
 
-    Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
+    Package.build(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
     assert [%User{id: ^user_id}] = HexWeb.Repo.get_by(Package, name: "ecto") |> assoc(:owners) |> HexWeb.Repo.all
     assert is_nil(HexWeb.Repo.get_by(Package, name: "postgrex"))
   end
 
   test "update package" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    package = Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
+    package = Package.build(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
 
     Package.update(package, %{"meta" => %{"maintainers" => ["eric", "josé"], "description" => "description", "licenses" => ["Apache"]}})
     |> HexWeb.Repo.update!
@@ -36,19 +36,19 @@ defmodule HexWeb.PackageTest do
       "description"  => ""}
 
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    assert {:error, changeset} = Package.create(user, pkg_meta(%{name: "ecto", meta: meta})) |> HexWeb.Repo.insert
+    assert {:error, changeset} = Package.build(user, pkg_meta(%{name: "ecto", meta: meta})) |> HexWeb.Repo.insert
     assert changeset.errors == []
     assert changeset.changes.meta.errors == [description: {"can't be blank", []}]
   end
 
   test "packages are unique" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    Package.create(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
-    assert {:error, _} = Package.create(user, pkg_meta(%{name: "ecto", description: "Domain-specific language"})) |> HexWeb.Repo.insert
+    Package.build(user, pkg_meta(%{name: "ecto", description: "DSL"})) |> HexWeb.Repo.insert!
+    assert {:error, _} = Package.build(user, pkg_meta(%{name: "ecto", description: "Domain-specific language"})) |> HexWeb.Repo.insert
   end
 
   test "reserved names" do
     user = HexWeb.Repo.get_by!(User, username: "eric")
-    assert {:error, %{errors: [name: {"is reserved", []}]}} = Package.create(user, pkg_meta(%{name: "elixir", description: "Awesomeness."})) |> HexWeb.Repo.insert
+    assert {:error, %{errors: [name: {"is reserved", []}]}} = Package.build(user, pkg_meta(%{name: "elixir", description: "Awesomeness."})) |> HexWeb.Repo.insert
   end
 end

--- a/test/models/release_test.exs
+++ b/test/models/release_test.exs
@@ -6,10 +6,10 @@ defmodule HexWeb.ReleaseTest do
   alias HexWeb.Release
 
   setup do
-    user = User.create(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
-    Package.create(user, pkg_meta(%{name: "ecto", description: "Ecto is awesome"})) |> HexWeb.Repo.insert!
-    Package.create(user, pkg_meta(%{name: "postgrex", description: "Postgrex is awesome"})) |> HexWeb.Repo.insert!
-    Package.create(user, pkg_meta(%{name: "decimal", description: "Decimal is awesome, too"})) |> HexWeb.Repo.insert!
+    user = User.build(%{username: "eric", email: "eric@mail.com", password: "eric"}, true) |> HexWeb.Repo.insert!
+    Package.build(user, pkg_meta(%{name: "ecto", description: "Ecto is awesome"})) |> HexWeb.Repo.insert!
+    Package.build(user, pkg_meta(%{name: "postgrex", description: "Postgrex is awesome"})) |> HexWeb.Repo.insert!
+    Package.build(user, pkg_meta(%{name: "decimal", description: "Decimal is awesome, too"})) |> HexWeb.Repo.insert!
     :ok
   end
 
@@ -18,11 +18,11 @@ defmodule HexWeb.ReleaseTest do
     package_id = package.id
 
     assert %Release{package_id: ^package_id, version: %Version{major: 0, minor: 0, patch: 1}} =
-           Release.create(package, rel_meta(%{version: "0.0.1", app: "ecto"}), "") |> HexWeb.Repo.insert!
+           Release.build(package, rel_meta(%{version: "0.0.1", app: "ecto"}), "") |> HexWeb.Repo.insert!
     assert %Release{package_id: ^package_id, version: %Version{major: 0, minor: 0, patch: 1}} =
            HexWeb.Repo.get_by!(assoc(package, :releases), version: "0.0.1")
 
-    Release.create(package, rel_meta(%{version: "0.0.2", app: "ecto"}), "") |> HexWeb.Repo.insert!
+    Release.build(package, rel_meta(%{version: "0.0.2", app: "ecto"}), "") |> HexWeb.Repo.insert!
     assert [%Release{version: %Version{major: 0, minor: 0, patch: 2}},
             %Release{version: %Version{major: 0, minor: 0, patch: 1}}] =
            Release.all(package) |> HexWeb.Repo.all |> Release.sort
@@ -33,16 +33,16 @@ defmodule HexWeb.ReleaseTest do
     postgrex = HexWeb.Repo.get_by(Package, name: "postgrex")
     decimal  = HexWeb.Repo.get_by(Package, name: "decimal")
 
-    Release.create(decimal, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
-    Release.create(decimal, rel_meta(%{version: "0.0.2", app: "decimal"}), "") |> HexWeb.Repo.insert!
+    Release.build(decimal, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
+    Release.build(decimal, rel_meta(%{version: "0.0.2", app: "decimal"}), "") |> HexWeb.Repo.insert!
 
     meta = rel_meta(%{requirements: [%{name: "decimal", app: "decimal", requirement: "~> 0.0.1", optional: false}],
                       app: "postgrex", version: "0.0.1"})
-    Release.create(postgrex, meta, "") |> HexWeb.Repo.insert!
+    Release.build(postgrex, meta, "") |> HexWeb.Repo.insert!
 
     meta = rel_meta(%{requirements: [%{name: "decimal", app: "decimal", requirement: "~> 0.0.2", optional: false}, %{name: "postgrex", app: "postgrex", requirement: "== 0.0.1", optional: false}],
                       app: "ecto", version: "0.0.1"})
-    Release.create(ecto, meta, "") |> HexWeb.Repo.insert!
+    Release.build(ecto, meta, "") |> HexWeb.Repo.insert!
 
     postgrex_id = postgrex.id
     decimal_id = decimal.id
@@ -58,23 +58,23 @@ defmodule HexWeb.ReleaseTest do
     decimal = HexWeb.Repo.get_by!(Package, name: "decimal")
     ecto = HexWeb.Repo.get_by!(Package, name: "ecto")
 
-    Release.create(decimal, rel_meta(%{version: "0.1.0", app: "decimal", requirements: []}), "")
+    Release.build(decimal, rel_meta(%{version: "0.1.0", app: "decimal", requirements: []}), "")
     |> HexWeb.Repo.insert!
 
     reqs = [%{name: "decimal", app: "decimal", requirement: "~> 0.1", optional: false}]
-    Release.create(ecto, rel_meta(%{version: "0.1.0", app: "ecto", requirements: reqs}), "")
+    Release.build(ecto, rel_meta(%{version: "0.1.0", app: "ecto", requirements: reqs}), "")
     |> HexWeb.Repo.insert!
 
     assert %{version: [{"is invalid", [type: HexWeb.Version]}]} =
-           Release.create(ecto, rel_meta(%{version: "0.1", app: "ecto"}), "") |> extract_errors
+           Release.build(ecto, rel_meta(%{version: "0.1", app: "ecto"}), "") |> extract_errors
 
     reqs = [%{name: "decimal", app: "decimal", requirement: "~> fail", optional: false}]
     assert %{requirements: [%{requirement: [{"invalid requirement: \"~> fail\"", []}]}]} =
-           Release.create(ecto, rel_meta(%{version: "0.1.1", app: "ecto", requirements: reqs}), "") |> extract_errors
+           Release.build(ecto, rel_meta(%{version: "0.1.1", app: "ecto", requirements: reqs}), "") |> extract_errors
 
     reqs = [%{name: "decimal", app: "decimal", requirement: "~> 1.0", optional: false}]
     assert %{requirements: [%{requirement: [{"Failed to use \"decimal\" because\n  You specified ~> 1.0 in your mix.exs\n", []}]}]} =
-           Release.create(ecto, rel_meta(%{version: "0.1.1", app: "ecto", requirements: reqs}), "") |> extract_errors
+           Release.build(ecto, rel_meta(%{version: "0.1.1", app: "ecto", requirements: reqs}), "") |> extract_errors
   end
 
   defp extract_errors(%Ecto.Changeset{} = changeset) do
@@ -85,11 +85,11 @@ defmodule HexWeb.ReleaseTest do
     ecto = HexWeb.Repo.get_by(Package, name: "ecto")
     postgrex = HexWeb.Repo.get_by(Package, name: "postgrex")
 
-    Release.create(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "") |> HexWeb.Repo.insert!
-    Release.create(postgrex, rel_meta(%{version: "0.0.1", app: "postgrex"}), "") |> HexWeb.Repo.insert!
+    Release.build(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "") |> HexWeb.Repo.insert!
+    Release.build(postgrex, rel_meta(%{version: "0.0.1", app: "postgrex"}), "") |> HexWeb.Repo.insert!
 
     assert {:error, %{errors: [version: {"has already been published", []}]}} =
-           Release.create(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "")
+           Release.build(ecto, rel_meta(%{version: "0.0.1", app: "ecto"}), "")
            |> HexWeb.Repo.insert
   end
 
@@ -97,9 +97,9 @@ defmodule HexWeb.ReleaseTest do
     decimal = HexWeb.Repo.get_by(Package, name: "decimal")
     postgrex = HexWeb.Repo.get_by(Package, name: "postgrex")
 
-    Release.create(decimal, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
+    Release.build(decimal, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
     reqs = [%{name: "decimal", app: "decimal", requirement: "~> 0.0.1", optional: false}]
-    release = Release.create(postgrex, rel_meta(%{version: "0.0.1", app: "postgrex", requirements: reqs}), "") |> HexWeb.Repo.insert!
+    release = Release.build(postgrex, rel_meta(%{version: "0.0.1", app: "postgrex", requirements: reqs}), "") |> HexWeb.Repo.insert!
 
     params = params(%{app: "postgrex", requirements: [%{name: "decimal", app: "decimal", requirement: ">= 0.0.1", optional: false}]})
     Release.update(release, params, "") |> HexWeb.Repo.update!
@@ -116,7 +116,7 @@ defmodule HexWeb.ReleaseTest do
     decimal = HexWeb.Repo.get_by(Package, name: "decimal")
     postgrex = HexWeb.Repo.get_by(Package, name: "postgrex")
 
-    release = Release.create(decimal, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
+    release = Release.build(decimal, rel_meta(%{version: "0.0.1", app: "decimal"}), "") |> HexWeb.Repo.insert!
     Release.delete(release) |> HexWeb.Repo.delete!
     refute HexWeb.Repo.get_by(assoc(postgrex, :releases), version: "0.0.1")
   end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -5,27 +5,27 @@ defmodule HexWeb.UserTest do
   alias HexWeb.User
 
   test "create user and auth" do
-    User.create(%{username: "eric", email: "eric@mail.com", password: "hunter42"}, true)
+    User.build(%{username: "eric", email: "eric@mail.com", password: "hunter42"}, true)
     |> HexWeb.Repo.insert!
     assert {:ok, %User{username: "eric"}} = Auth.password_auth("eric", "hunter42")
   end
 
   test "create user and fail auth" do
-    User.create(%{username: "eric", email: "eric@mail.com", password: "erics_pass"}, true)
+    User.build(%{username: "eric", email: "eric@mail.com", password: "erics_pass"}, true)
     |> HexWeb.Repo.insert!
     assert :error == Auth.password_auth("josé", "erics_pass")
     assert :error == Auth.password_auth("eric", "wrong_pass")
   end
 
   test "users name and email are unique" do
-    User.create(%{username: "eric", email: "eric@mail.com", password: "erics_pass"}, true)
+    User.build(%{username: "eric", email: "eric@mail.com", password: "erics_pass"}, true)
     |> HexWeb.Repo.insert!
-    assert {:error, _} = User.create(%{username: "eric", email: "mail@mail.com", password: "pass"}, true) |> HexWeb.Repo.insert
-    assert {:error, _} = User.create(%{username: "name", email: "eric@mail.com", password: "pass"}, true) |> HexWeb.Repo.insert
+    assert {:error, _} = User.build(%{username: "eric", email: "mail@mail.com", password: "pass"}, true) |> HexWeb.Repo.insert
+    assert {:error, _} = User.build(%{username: "name", email: "eric@mail.com", password: "pass"}, true) |> HexWeb.Repo.insert
   end
 
   test "update user" do
-    user = User.create(%{username: "eric", email: "eric@mail.com", password: "erics_pass"}, true)
+    user = User.build(%{username: "eric", email: "eric@mail.com", password: "erics_pass"}, true)
            |> HexWeb.Repo.insert!
     User.update(user, %{username: "eric", password: "new_pass"})
     |> HexWeb.Repo.update!

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -51,7 +51,7 @@ defmodule HexWeb.ConnCase do
 
   def key_for(user) do
     key = user
-          |> HexWeb.Key.create(%{name: "any_key_name"})
+          |> HexWeb.Key.build(%{name: "any_key_name"})
           |> HexWeb.Repo.insert!
     key.user_secret
   end

--- a/web/controllers/api/key_controller.ex
+++ b/web/controllers/api/key_controller.ex
@@ -27,7 +27,7 @@ defmodule HexWeb.API.KeyController do
 
     multi =
       Ecto.Multi.new
-      |> Ecto.Multi.insert(:key, Key.create(user, params))
+      |> Ecto.Multi.insert(:key, Key.build(user, params))
       |> Ecto.Multi.insert(:log, fn %{key: key} -> audit(conn, "key.generate", key) end)
 
     case HexWeb.Repo.transaction(multi) do

--- a/web/controllers/api/owner_controller.ex
+++ b/web/controllers/api/owner_controller.ex
@@ -31,7 +31,7 @@ defmodule HexWeb.API.OwnerController do
 
     multi =
       Ecto.Multi.new
-      |> Ecto.Multi.insert(:owner, Package.create_owner(conn.assigns.package, owner))
+      |> Ecto.Multi.insert(:owner, Package.build_owner(conn.assigns.package, owner))
       |> Ecto.Multi.insert(:log, audit(conn, "owner.add", {package, owner}))
 
     case HexWeb.Repo.transaction(multi) do

--- a/web/controllers/api/release_controller.ex
+++ b/web/controllers/api/release_controller.ex
@@ -82,7 +82,7 @@ defmodule HexWeb.API.ReleaseController do
       Package.update(package, params)
       |> HexWeb.Repo.update
     else
-      Package.create(user, params)
+      Package.build(user, params)
       |> HexWeb.Repo.insert
     end
   end
@@ -124,7 +124,7 @@ defmodule HexWeb.API.ReleaseController do
   defp create(conn, package, params, checksum, user, body) do
     multi =
       Ecto.Multi.new
-      |> Ecto.Multi.insert(:release, Release.create(package, params, checksum))
+      |> Ecto.Multi.insert(:release, Release.build(package, params, checksum))
       |> Ecto.Multi.insert(:log, fn %{release: release} -> audit(user, "release.publish", {package, release}) end)
 
     case HexWeb.Repo.transaction(multi) do

--- a/web/controllers/api/user_controller.ex
+++ b/web/controllers/api/user_controller.ex
@@ -12,7 +12,7 @@ defmodule HexWeb.API.UserController do
       HexWeb.Repo.delete!(user)
     end
 
-    case User.create(params) |> HexWeb.Repo.insert do
+    case User.build(params) |> HexWeb.Repo.insert do
       {:ok, user} ->
         HexWeb.Mailer.send(
           "confirmation_request.html",

--- a/web/controllers/controller_helpers.ex
+++ b/web/controllers/controller_helpers.ex
@@ -193,6 +193,6 @@ defmodule HexWeb.ControllerHelpers do
     audit(user, action, params)
   end
   def audit(user, action, params) do
-    Ecto.Changeset.change(HexWeb.AuditLog.create(user, action, params), %{})
+    Ecto.Changeset.change(HexWeb.AuditLog.build(user, action, params), %{})
   end
 end

--- a/web/models/audit_log.ex
+++ b/web/models/audit_log.ex
@@ -8,11 +8,7 @@ defmodule HexWeb.AuditLog do
     timestamps(updated_at: false)
   end
 
-  def build(actor, action, params) do
-    %HexWeb.AuditLog{actor_id: actor.id, action: action, params: params}
-  end
-
-  def create(%HexWeb.User{id: user_id}, action, params) do
+  def build(%HexWeb.User{id: user_id}, action, params) do
     params = extract_params(action, params)
     %HexWeb.AuditLog{actor_id: user_id, action: action, params: params}
   end

--- a/web/models/install.ex
+++ b/web/models/install.ex
@@ -36,7 +36,7 @@ defmodule HexWeb.Install do
     end
   end
 
-  def create(hex, elixirs) do
+  def build(hex, elixirs) do
     change(%HexWeb.Install{}, hex: hex, elixirs: elixirs)
   end
 end

--- a/web/models/key.ex
+++ b/web/models/key.ex
@@ -25,7 +25,7 @@ defmodule HexWeb.Key do
     |> prepare_changes(&unique_name/1)
   end
 
-  def create(user, params) do
+  def build(user, params) do
     build_assoc(user, :keys)
     |> changeset(params)
   end

--- a/web/models/package.ex
+++ b/web/models/package.ex
@@ -44,7 +44,7 @@ defmodule HexWeb.Package do
     |> validate_exclusion(:name, @reserved_names)
   end
 
-  def create(owner, params) do
+  def build(owner, params) do
     changeset(%Package{}, :create, params)
     |> put_assoc(:package_owners, [%PackageOwner{owner_id: owner.id}])
   end
@@ -73,7 +73,7 @@ defmodule HexWeb.Package do
          select: {p.name, p.updated_at})
   end
 
-  def create_owner(package, user) do
+  def build_owner(package, user) do
     change(%PackageOwner{}, package_id: package.id, owner_id: user.id)
     |> unique_constraint(:owner_id, name: "package_owners_unique", message: "is already owner")
   end

--- a/web/models/registry.ex
+++ b/web/models/registry.ex
@@ -8,7 +8,7 @@ defmodule HexWeb.Registry do
     field :started_at, Ecto.DateTime
   end
 
-  def create do
+  def build do
     %HexWeb.Registry{}
     |> change(state: "waiting")
     |> prepare_changes(&delete_defaults/1)

--- a/web/models/release.ex
+++ b/web/models/release.ex
@@ -28,7 +28,7 @@ defmodule HexWeb.Release do
     |> validate_version(:version)
   end
 
-  def create(package, params, checksum) do
+  def build(package, params, checksum) do
     build_assoc(package, :releases)
     |> changeset(:create, params)
     |> put_change(:checksum, String.upcase(checksum))

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -41,7 +41,7 @@ defmodule HexWeb.User do
     |> validate_format(:username, ~r"^[a-z0-9_\-\.!~\*'\(\)]+$")
   end
 
-  def create(params, confirmed? \\ not Application.get_env(:hex_web, :user_confirm)) do
+  def build(params, confirmed? \\ not Application.get_env(:hex_web, :user_confirm)) do
     changeset(%User{}, :create, params)
     |> put_change(:confirmation_key, HexWeb.Auth.gen_key())
     |> put_change(:confirmed, confirmed?)


### PR DESCRIPTION
Most occurences of `create` in app code are gone:

    hex_web[wm-rename-create-to-build]% ag create web/{models,controllers}
    web/models/package.ex
    34:  defp changeset(package, :create, params) do
    48:    changeset(%Package{}, :create, params)

    web/models/release.ex
    19:  defp changeset(release, :create, params) do
    33:    |> changeset(:create, params)

    web/models/user.ex
    25:  defp changeset(user, :create, params) do
    45:    changeset(%User{}, :create, params)

    web/controllers/api/docs_controller.ex
    22:  def create(conn, %{"body" => body}) do

    web/controllers/api/key_controller.ex
    4:  plug :authorize when action != :create
    5:  plug :authorize, [only_basic: true, allow_unconfirmed: true] when action == :create
    25:  def create(conn, params) do

    web/controllers/api/owner_controller.ex
    27:  def create(conn, %{"email" => email}) do

    web/controllers/api/user_controller.ex
    6:  def create(conn, params) do
    7:    # Unconfirmed users can be recreated

    web/controllers/api/release_controller.ex
    4:  plug :fetch_release when action != :create
    7:  def create(conn, %{"name" => name, "body" => body}) do
    65:        case create_package(user, package, package_params) do
    67:            create_release(conn, package, user, checksum, meta, body)
    77:  defp create_package(user, package, params) do
    90:  defp create_release(conn, package, user, checksum, meta, body) do
    102:      create(conn, package, release_params, checksum, user, body)
    124:  defp create(conn, package, params, checksum, user, body) do