### PR TITLE
Allow extra searchable metadata in package

### DIFF
--- a/priv/repo/migrations/20160610143806_add_meta_extra_index.exs
+++ b/priv/repo/migrations/20160610143806_add_meta_extra_index.exs
@@ -1,0 +1,14 @@
+defmodule HexWeb.Repo.Migrations.AddMetaExtraIndex do
+  use Ecto.Migration
+
+  def up do
+    execute """
+      CREATE INDEX packages_meta_extra_idx ON
+        packages USING GIN ((meta->'extra') jsonb_path_ops)
+    """
+  end
+
+  def down do
+    execute "DROP INDEX IF EXISTS packages_meta_extra_idx"
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -27,8 +27,9 @@ HexWeb.Repo.transaction(fn ->
   eric = SampleData.create_user("eric", "eric@example.com", "eric")
   jose = SampleData.create_user("jose", "jose@example.com", "jose")
   joe = SampleData.create_user("joe", "joe@example.com", "joe")
+  justin = SampleData.create_user("justin", "justin@example.com", "justin")
 
-  if eric == nil or jose == nil or joe == nil do
+  if eric == nil or jose == nil or joe == nil or justin == nil do
     IO.puts "\nThere has been an error creating the sample users.\nIf the error says '... already taken' hex_web was probably already set up."
   end
 
@@ -117,6 +118,49 @@ HexWeb.Repo.transaction(fn ->
 
       {:ok, yesterday} = Ecto.Type.load(Ecto.Date, HexWeb.Utils.yesterday)
       %Download{release_id: rel2.id, downloads: div(index, 2) + rem(index, 2), day: yesterday}
+      |> HexWeb.Repo.insert!
+    end)
+  end
+
+  unless justin == nil do
+    nerves =
+      Package.build(justin, %{
+        "name" => "nerves",
+        "meta" => %{
+          "maintainers" => ["Justin Schneck", "Frank Hunleth"],
+          "licenses" => ["Apache 2.0"],
+          "links" => %{"Github" => "http://example.com/github"},
+          "description" => lorem,
+          "extra" => %{
+            "foo" => %{"bar" => "baz"},
+            "key" => "value 1"}}})
+      |> HexWeb.Repo.insert!
+
+    rel = Release.build(nerves, %{"version" => "0.0.1", "app" => "nerves", "meta" => %{"app" => "nerves", "build_tools" => ["mix"]}}, SampleData.checksum("nerves 0.0.1")) |> HexWeb.Repo.insert!
+
+    {:ok, yesterday} = Ecto.Type.load(Ecto.Date, HexWeb.Utils.yesterday)
+    %Download{release_id: rel.id, downloads: 20, day: yesterday}
+    |> HexWeb.Repo.insert!
+
+    Enum.each(1..10, fn(index) ->
+      nerves_pkg =
+        Package.build(justin, %{
+          "name" => "nerves_pkg_#{index}",
+          "meta" => %{
+            "maintainers" => ["Justin Schneck", "Frank Hunleth"],
+            "licenses" => ["Apache 2.0"],
+            "links" => %{"Github" => "http://example.com/github"},
+            "description" => lorem,
+            "extra" => %{
+              "list" => ["a", "b", "c"],
+              "foo" => %{"bar" => "baz"},
+              "key" => "value"}}})
+        |> HexWeb.Repo.insert!
+
+      rel = Release.build(nerves_pkg, %{"version" => "0.0.1", "app" => "nerves_pkg_#{index}", "meta" => %{"app" => "nerves_pkg_#{index}", "build_tools" => ["mix"]}}, SampleData.checksum("nerves_pkg_#{index} 0.0.1")) |> HexWeb.Repo.insert!
+
+      {:ok, yesterday} = Ecto.Type.load(Ecto.Date, HexWeb.Utils.yesterday)
+      %Download{release_id: rel.id, downloads: div(index, 2) + rem(index, 2), day: yesterday}
       |> HexWeb.Repo.insert!
     end)
   end

--- a/test/controllers/api/package_controller_test.exs
+++ b/test/controllers/api/package_controller_test.exs
@@ -42,6 +42,11 @@ defmodule HexWeb.API.PackageControllerTest do
     body = Poison.decode!(conn.resp_body)
     assert length(body) == 1
 
+    conn = get build_conn(), "api/packages?search=name%3Apost%25"
+    assert conn.status == 200
+    body = Poison.decode!(conn.resp_body)
+    assert length(body) == 1
+
     conn = get build_conn(), "api/packages?page=1"
     assert conn.status == 200
     body = Poison.decode!(conn.resp_body)

--- a/test/models/audit_log_test.exs
+++ b/test/models/audit_log_test.exs
@@ -12,7 +12,7 @@ defmodule HexWeb.AuditLogTest do
         action: "owner.add",
         params: %{
           package: %{id: 2, name: "ecto",
-                     meta: %{maintainers: nil, description: "some description", licenses: nil, links: nil, maintainers: nil}},
+                     meta: %{maintainers: nil, description: "some description", licenses: nil, links: nil, maintainers: nil, extra: nil}},
           user: %{id: 3, username: "eric", email: "eric@mail.com", confirmed: true}}}
   end
 end

--- a/test/models/package_test.exs
+++ b/test/models/package_test.exs
@@ -51,4 +51,37 @@ defmodule HexWeb.PackageTest do
     user = HexWeb.Repo.get_by!(User, username: "eric")
     assert {:error, %{errors: [name: {"is reserved", []}]}} = Package.build(user, pkg_meta(%{name: "elixir", description: "Awesomeness."})) |> HexWeb.Repo.insert
   end
+
+  test "search extra metadata" do
+    meta = %{
+      "maintainers"  => ["justin"],
+      "licenses"     => ["apache", "BSD"],
+      "links"        => %{"github" => "www", "docs" => "www"},
+      "description"  => "description",
+      "extra"        => %{"foo" => %{"bar" => "baz"}, "list" => ["a", 1]}}
+
+    meta2 = Map.put(meta, "extra", %{"foo" => %{"bar" => "baz"}, "list" => ["b", 2]})
+
+    user = HexWeb.Repo.get_by!(User, username: "eric")
+
+    Package.build(user, pkg_meta(%{name: "nerves", description: "DSL"}))
+    |> HexWeb.Repo.insert!
+    |> Package.update(%{"meta" => meta})
+    |> HexWeb.Repo.update!
+
+    Package.build(user, pkg_meta(%{name: "nerves_pkg", description: "DSL"}))
+    |> HexWeb.Repo.insert!
+    |> Package.update(%{"meta" => meta2})
+    |> HexWeb.Repo.update!
+
+    search = [
+      {"name:nerves extra:list,[a]", 1},
+      {"name:nerves% extra:foo,bar,baz", 2},
+      {"name:nerves% extra:list,[1]", 1}]
+    for {s, len} <- search do
+      p = Package.all(1, 10, s, nil)
+      |> HexWeb.Repo.all
+      assert length(p) == len
+    end
+  end
 end

--- a/web/controllers/api/package_controller.ex
+++ b/web/controllers/api/package_controller.ex
@@ -6,7 +6,7 @@ defmodule HexWeb.API.PackageController do
 
   def index(conn, params) do
     page     = HexWeb.Utils.safe_int(params["page"])
-    search   = HexWeb.Utils.safe_search(params["search"])
+    search   = HexWeb.Utils.parse_search(params["search"])
     sort     = HexWeb.Utils.safe_to_atom(params["sort"] || "name", @sort_params)
 
     packages =

--- a/web/controllers/package_controller.ex
+++ b/web/controllers/package_controller.ex
@@ -6,8 +6,8 @@ defmodule HexWeb.PackageController do
   @letters for letter <- ?A..?Z, do: <<letter>>
 
   def index(conn, params) do
-    letter        = HexWeb.Utils.safe_search(params["letter"])
-    search        = HexWeb.Utils.safe_search(params["search"])
+    letter        = HexWeb.Utils.parse_search(params["letter"])
+    search        = HexWeb.Utils.parse_search(params["search"])
 
     filter =
       cond do

--- a/web/models/audit_log.ex
+++ b/web/models/audit_log.ex
@@ -35,6 +35,6 @@ defmodule HexWeb.AuditLog do
   defp fields(%HexWeb.Package{}), do: [:id, :name]
   defp fields(%HexWeb.Release{}), do: [:id, :version, :checksum, :has_docs, :package_id]
   defp fields(%HexWeb.User{}), do: [:id, :username, :email, :confirmed]
-  defp fields(%HexWeb.PackageMetadata{}), do: [:description, :licenses, :links, :maintainers]
+  defp fields(%HexWeb.PackageMetadata{}), do: [:description, :licenses, :links, :maintainers, :extra]
   defp fields(%HexWeb.ReleaseMetadata{}), do: [:app, :build_tools, :elixir]
 end

--- a/web/models/package_metadata.ex
+++ b/web/models/package_metadata.ex
@@ -6,10 +6,11 @@ defmodule HexWeb.PackageMetadata do
     field :licenses, {:array, :string}
     field :links, :map
     field :maintainers, {:array, :string}
+    field :extra, :map
   end
 
   def changeset(meta, params \\ %{}) do
-    cast(meta, params, ~w(description licenses links maintainers))
+    cast(meta, params, ~w(description licenses links maintainers extra))
     |> validate_required(:description)
     |> validate_required(:licenses)
   end

--- a/web/utils.ex
+++ b/web/utils.ex
@@ -66,8 +66,9 @@ defmodule HexWeb.Utils do
     end
   end
 
-  def safe_search(nil), do: nil
-  def safe_search(""), do: nil
+  def parse_search(nil), do: nil
+  def parse_search(""), do: nil
+  def parse_search(search), do: search
   def safe_search(string) do
     string
     |> String.replace(~r/\//u, " ")


### PR DESCRIPTION
WIP

Added fields and tests to have package_metadata contain extra map.

Todo:
extend search API to pass object path and search words

Tracked alongside
https://github.com/hexpm/hex/pull/234
https://github.com/hexpm/specifications/pull/6
