### PR TITLE
Sort package search results by downloads

### DIFF
--- a/web/templates/layout/header.html.eex
+++ b/web/templates/layout/header.html.eex
@@ -35,6 +35,7 @@
           <form class="navbar-form pull-left" role="search" action="<%= package_path(HexWeb.Endpoint, :index) %>">
              <div class="input-group">
                 <input placeholder="Find packages" name="search" type="text" autofocus class="form-control" value="<%= search(assigns) %>">
+                <input type="hidden" name="sort" value="downloads">
 
                 <div class="input-group-btn">
                   <button type="submit" class="btn btn-search" tabindex="1">


### PR DESCRIPTION
Makes the header search field consistent with the homepage.

See https://github.com/hexpm/hex_web/blob/master/web/templates/page/index.html.eex#L11