### PR TITLE
Update Rollbax to the latest version (0.6.1)

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -21,9 +21,9 @@ config :rollbax,
   enabled: true
 
 config :logger,
-  backends: [Rollbax.Notifier, :console]
+  backends: [Rollbax.Logger, :console]
 
-config :logger, Rollbax.Notifier,
+config :logger, Rollbax.Logger,
   level: :error
 
 # Don't include date time on heroku

--- a/mix.lock
+++ b/mix.lock
@@ -23,11 +23,11 @@
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.5", "829218c4152ba1e9848e2bf8e161fcde6b4ec679a516259442561d21fde68d0b", [:mix], [{:phoenix, "~> 1.0 or ~> 1.2-rc", [hex: :phoenix, optional: false]}, {:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.0-rc.0", "5c9453f9c7c8e4982ba48f408e4cec973ffb312bbe0da5fbe47899b9c91c48c0", [:mix], []},
   "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
-  "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
   "porcelain": {:hex, :porcelain, "2.0.1", "9c3db2b47d8cf6879c0d9ac79db8657333974a88faff09e856569e00c1b5e119", [:mix], []},
   "postgrex": {:hex, :postgrex, "0.11.2", "139755c1359d3c5c6d6e8b1ea72556d39e2746f61c6ddfb442813c91f53487e8", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
-  "rollbax": {:hex, :rollbax, "0.5.4", "1e11cf273e6f7b73c932955157cb83d1bfcb464e76b60a48dfc78d381a5efdfd", [:mix], [{:poison, "~> 1.4 or ~> 2.0", [hex: :poison, optional: false]}, {:hackney, "~> 1.1", [hex: :hackney, optional: false]}]},
+  "rollbax": {:hex, :rollbax, "0.6.1", "412065ca6544a8a654dd636ea825f329b12a02f124f2c61058e49e5c7fc15040", [:mix], [{:poison, "~> 1.4 or ~> 2.0", [hex: :poison, optional: false]}, {:hackney, "~> 1.1", [hex: :hackney, optional: false]}]},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "sweet_xml": {:hex, :sweet_xml, "0.6.1", "a56f235171f35a32807ce44798dedc748ce249fca574674fecd29c1321cab0de", [:mix], []}}


### PR DESCRIPTION
This version brings many improvements to the format of items reported to Rollbar and fixes some bugs here and there.