### PR TITLE
Fix broken policies link in confirmation email

### DIFF
--- a/test/controllers/api/user_controller_test.exs
+++ b/test/controllers/api/user_controller_test.exs
@@ -35,6 +35,10 @@ defmodule HexWeb.API.UserControllerTest do
     assert subject =~ "Hex.pm"
     assert contents =~ "confirm?username=name&key=" <> user.confirmation_key
 
+    policies_href = ~s(http://localhost:4001/policies)
+    policies_link = ~s(<a href="#{policies_href}">#{policies_href}</a>)
+    assert contents =~ ~s(all of our policies found at #{policies_link})
+
     meta = %{name: "ecto", version: "1.0.0", description: "Domain-specific language."}
     body = create_tar(meta, [])
     conn = build_conn()

--- a/web/templates/email/confirmation_request.html.eex
+++ b/web/templates/email/confirmation_request.html.eex
@@ -13,7 +13,7 @@ confirm_url = password_url(HexWeb.Endpoint, :show_confirm, username: @username, 
 </p>
 
 <p>
-  By confirming your account you accept our terms of service and all of our policies found at <a href="<%= policy_path(HexWeb.Endpoint, :index) %>"><%= policy_path(HexWeb.Endpoint, :index) %></a>.
+  By confirming your account you accept our terms of service and all of our policies found at <a href="<%= policy_url(HexWeb.Endpoint, :index) %>"><%= policy_url(HexWeb.Endpoint, :index) %></a>.
 </p>
 
 <p>


### PR DESCRIPTION
I've noticed, that policies link in confirmation email is invalid. This should fix the issue.

![image](https://cloud.githubusercontent.com/assets/883341/16665345/e8ef7e82-448b-11e6-83f8-1fea0e4c4d34.png)

