### PR TITLE
Break out Repo access from API.OwnerController

### DIFF
--- a/web/controllers/controller_helpers.ex
+++ b/web/controllers/controller_helpers.ex
@@ -200,6 +200,11 @@ defmodule HexWeb.ControllerHelpers do
     HexWeb.AuthHelpers.authorized(conn, opts, &fun.(conn, &1))
   end
 
+  def audit_data(conn) do
+    {conn.assigns.user, conn.assigns.user_agent}
+  end
+
+  # TODO: remove once auditing is moved out of all controllers
   def audit(multi, conn, action, fun) when is_function(fun, 1) do
     Ecto.Multi.merge(multi, fn data ->
       Ecto.Multi.insert(Ecto.Multi.new, :log, audit(conn, action, fun.(data)))

--- a/web/models/audit_log.ex
+++ b/web/models/audit_log.ex
@@ -20,6 +20,10 @@ defmodule HexWeb.AuditLog do
     }
   end
 
+  def audit(%Ecto.Multi{} = multi, {user, user_agent}, action, params) do
+    Ecto.Multi.insert(multi, :log, build(user, user_agent, action, params))
+  end
+
   defp extract_params("docs.publish", {package, release}), do: %{package: serialize(package), release: serialize(release)}
   defp extract_params("docs.revert", {package, release}), do: %{package: serialize(package), release: serialize(release)}
   defp extract_params("key.generate", key), do: serialize(key)

--- a/web/models/owners.ex
+++ b/web/models/owners.ex
@@ -1,0 +1,62 @@
+defmodule HexWeb.Owners do
+  use HexWeb.Web, :crud
+
+  def all(package) do
+    assoc(package, :owners)
+    |> Repo.all
+  end
+
+  def get(email) do
+    Repo.get_by!(User, email: email)
+  end
+
+  def add(package, owner, [audit: audit_data]) do
+    multi =
+      Ecto.Multi.new
+      |> Ecto.Multi.insert(:owner, Package.build_owner(package, owner))
+      |> audit(audit_data, "owner.add", {package, owner})
+
+    case Repo.transaction(multi) do
+      {:ok, _} ->
+        owners = all(package)
+
+        HexWeb.Mailer.send(
+          "owner_add.html",
+          "Hex.pm - Owner added",
+          Enum.map(owners, & &1.email),
+          username: owner.username,
+          email: owner.email,
+          package: package.name
+        )
+        :ok
+
+      {:error, :owner, changeset, _} ->
+        {:error, changeset}
+    end
+  end
+
+  def remove(package, owner, [audit: audit_data]) do
+    owners = all(package)
+
+    if length(owners) == 1 do
+      {:error, :last_owner}
+    else
+      multi =
+        Ecto.Multi.new
+        |> Ecto.Multi.delete_all(:package_owner, Package.owner(package, owner))
+        |> audit(audit_data, "owner.remove", {package, owner})
+
+      {:ok, _} = Repo.transaction(multi)
+
+      HexWeb.Mailer.send(
+        "owner_remove.html",
+        "Hex.pm - Owner removed",
+        Enum.map(owners, & &1.email),
+        username: owner.username,
+        email: owner.email,
+        package: package.name
+      )
+      :ok
+    end
+  end
+end

--- a/web/web.ex
+++ b/web/web.ex
@@ -29,6 +29,16 @@ defmodule HexWeb.Web do
     end
   end
 
+  def crud do
+    quote do
+      alias HexWeb.Repo
+      import Ecto
+      import HexWeb.AuditLog, only: [audit: 4]
+
+      HexWeb.Web.shared
+    end
+  end
+
   def controller do
     quote do
       use Phoenix.Controller


### PR DESCRIPTION
See #386.

I started looking into an "easy" controller first, `API.OwnerController`, to figure out naming & conventions, before going down the rabbit hole with the most complex ones, docs & releases.