### PR TITLE
Make Online Documentation link release specific too

### DIFF
--- a/web/controllers/package_controller.ex
+++ b/web/controllers/package_controller.ex
@@ -59,11 +59,16 @@ defmodule HexWeb.PackageController do
 
   defp package(conn, package, releases, release) do
     has_docs = Enum.any?(releases, fn(release) -> release.has_docs end)
+    latest_release? = List.first(releases) == release
     release = Releases.preload(release)
 
     docs_assigns =
       if has_docs do
-        [hexdocs_url: HexWeb.Utils.docs_url(package, release),
+        docs_url = case latest_release? do
+                     true -> HexWeb.Utils.docs_url([package.name])
+                     false -> HexWeb.Utils.docs_url(package, release)
+                   end
+        [hexdocs_url: docs_url,
          docs_tarball_url: HexWeb.Utils.docs_tarball_url(package, release)]
       else
         [hexdocs_url: nil, docs_tarball_url: nil]

--- a/web/controllers/package_controller.ex
+++ b/web/controllers/package_controller.ex
@@ -63,7 +63,7 @@ defmodule HexWeb.PackageController do
 
     docs_assigns =
       if has_docs do
-        [hexdocs_url: HexWeb.Utils.docs_url([package.name]),
+        [hexdocs_url: HexWeb.Utils.docs_url(package, release),
          docs_tarball_url: HexWeb.Utils.docs_tarball_url(package, release)]
       else
         [hexdocs_url: nil, docs_tarball_url: nil]


### PR DESCRIPTION
Hello,

Now "Online Documentation" link isn't specific to release version (while tarball link is) which is very confusing.
This patch should fix this.

Thanks.