### PR TITLE
Adding dev docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM elixir:1.3.2
+
+RUN mix local.hex --force
+
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get install -y nodejs postgresql-client
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY mix.exs /usr/src/app/mix.exs
+COPY mix.lock /usr/src/app/mix.lock
+RUN mix deps.get
+
+COPY package.json /usr/src/app/package.json
+RUN npm install
+
+COPY . /usr/src/app
+RUN mix compile
+
+CMD ["mix", "phoenix.server"]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -33,5 +33,5 @@ config :hex_web, HexWeb.Repo,
   username: "postgres",
   password: "postgres",
   database: "hexweb_dev",
-  hostname: "localhost",
+  hostname: System.get_env("DEV_DATABASE_HOST") || "localhost",
   pool_size: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2'
+services:
+  web:
+    build: .
+    ports:
+      - "4000:4000"
+    depends_on:
+      - postgres
+    environment:
+      - DEV_DATABASE_HOST=postgres
+    command: sh -c "./wait-for-postgres.sh postgres postgres && mix ecto.migrate HexWeb.Repo && mix phoenix.server"
+
+  postgres:
+    image: postgres
+    environment:
+     - POSTGRES_USER=postgres
+     - POSTGRES_PASSWORD=postgres
+     - POSTGRES_DB=hexweb_dev

--- a/wait-for-postgres.sh
+++ b/wait-for-postgres.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+host="$1"
+pw="$2"
+
+until PGPASSWORD="$pw" psql -h "$host" -U "postgres" -c '\l'; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done


### PR DESCRIPTION
Here's a very simple docker based environment for development only. The database URL needs to be read from env variable for this to work, hence the change to `dev.exs`. The compose file creates an elixir 1.3.2 container and pulls in postgres. To get a hex_web server running use the following command in the project root directory:

```
docker-compose up --build
```

NOTE: docker and docker-compose must be installed.