### PR TITLE
Email support

### DIFF
--- a/web/auth.ex
+++ b/web/auth.ex
@@ -33,8 +33,8 @@ defmodule HexWeb.Auth do
     end
   end
 
-  def password_auth(username, password) do
-    if (user = HexWeb.Repo.get_by(HexWeb.User, username: username)) &&
+  def password_auth(username_or_email, password) do
+    if (user = HexWeb.Users.get(username_or_email)) &&
        Comeonin.Bcrypt.checkpw(password, user.password) do
       {:ok, {user, nil}}
     else

--- a/web/controllers/auth_helpers.ex
+++ b/web/controllers/auth_helpers.ex
@@ -55,8 +55,8 @@ defmodule HexWeb.AuthHelpers do
 
   defp basic_auth(credentials) do
     case String.split(Base.decode64!(credentials), ":", parts: 2) do
-      [username, password] ->
-        case HexWeb.Auth.password_auth(username, password) do
+      [username_or_email, password] ->
+        case HexWeb.Auth.password_auth(username_or_email, password) do
           {:ok, user} -> {:ok, user}
           :error -> {:error, :basic}
         end

--- a/web/models/users.ex
+++ b/web/models/users.ex
@@ -1,8 +1,11 @@
 defmodule HexWeb.Users do
   use HexWeb.Web, :crud
 
-  def get(username) do
-    Repo.get_by(User, username: username)
+  def get(username_or_email) do
+    Repo.one(
+      from u in HexWeb.User,
+      where: u.username == ^username_or_email or u.email == ^username_or_email
+    )
   end
 
   def with_owned_packages(user) do


### PR DESCRIPTION
Giving #358 a shot.

From what I could notice by grepping the codebase and reading the [API Spec](https://github.com/hexpm/specifications), we use the username only to fetch the user. Since I don't know the codebase well, I'd appreciate some pointers if there are more changes to be done in this codebase (which I suspect is the case).

I am aware that [hex](https://github.com/hexpm/hex) should change as well, but I'd consider that a next step.