### PR TITLE
AuthHelpers.correct_user?/2 should support email user validation

### DIFF
--- a/web/controllers/auth_helpers.ex
+++ b/web/controllers/auth_helpers.ex
@@ -103,6 +103,6 @@ defmodule HexWeb.AuthHelpers do
 
   def correct_user?(%Plug.Conn{} = conn, user),
     do: correct_user?(conn.params["name"], user)
-  def correct_user?(name, user) when is_binary(name),
-    do: name == user.username
+  def correct_user?(username_or_email, user) when is_binary(username_or_email),
+    do: username_or_email in [user.username, user.email]
 end


### PR DESCRIPTION
Related to #358  and #413

`AuthHelpers.correct_user?/2` should be able to validate users based on username as well as email. This change makes authorization comply with changes done on the aforementioned issue/PR.