### PR TITLE
Adds OpenGraph tags

### DIFF
--- a/web/templates/layout/header.html.eex
+++ b/web/templates/layout/header.html.eex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" prefix="og: http://ogp.me/ns#">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -7,6 +7,8 @@
     <meta name="description" content="<%= description(assigns) %>">
 
     <title><%= title(assigns) %></title>
+
+    <%= og_tags(assigns) %>
 
     <link rel="search" type="application/opensearchdescription+xml" title="Hex" href="/hexsearch.xml">
     <link rel="stylesheet" href="<%= static_path(HexWeb.Endpoint, "/css/main.css") %>">

--- a/web/views/layout_view.ex
+++ b/web/views/layout_view.ex
@@ -36,4 +36,15 @@ defmodule HexWeb.LayoutView do
   def container_class(assigns) do
     Map.get(assigns, :container, "container page")
   end
+
+  def og_tags(assigns) do
+    [
+      tag(:meta, property: "og:title", content: Map.get(assigns, :title)),
+      tag(:meta, property: "og:type", content: "website"),
+      tag(:meta, property: "og:url", content: Map.get(assigns, :canonical_url)),
+      tag(:meta, property: "og:image", content: static_url(HexWeb.Endpoint, "/images/hex.png")),
+      tag(:meta, property: "og:description", content: description(assigns)),
+      tag(:meta, property: "og:site_name", content: "Hex")
+    ]
+  end
 end


### PR DESCRIPTION
Adds basic [OpenGraph](http://ogp.me/) tags to provide rich links in platforms such as Facebook, Twitter, Google Plus and LinkedIn.

With this PR links to hex.pm should be rendered as fancy cards in social networks.