### PR TITLE
do a redirect instead of rendering changeset error message

### DIFF
--- a/test/controllers/dashboard_controller_test.exs
+++ b/test/controllers/dashboard_controller_test.exs
@@ -151,9 +151,10 @@ defmodule HexWeb.DashboardControllerTest do
            |> test_login(c.user)
            |> post("dashboard/email", %{email: %{email: email}})
 
-    response(conn, 400)
-    assert conn.resp_body =~ "Add email"
-    assert conn.resp_body =~ "has already been taken"
+    assert redirected_to(conn) == "/dashboard/email"
+    assert get_flash(conn, :error) =~ "already in use"
+    user = HexWeb.Repo.get!(HexWeb.User, c.user.id) |> HexWeb.Repo.preload(:emails)
+    assert Enum.count(user.emails, &(&1.email == email)) === 1
   end
 
   test "remove email", c do

--- a/web/controllers/dashboard_controller.ex
+++ b/web/controllers/dashboard_controller.ex
@@ -55,17 +55,16 @@ defmodule HexWeb.DashboardController do
 
   def add_email(conn, params) do
     user = Users.with_emails(conn.assigns.logged_in)
-
+    email = params["email"]["email"]
     case Users.add_email(user, params["email"], audit: audit_data(conn)) do
       {:ok, _user} ->
-        email = params["email"]["email"]
         conn
         |> put_flash(:info, "A verification email has been sent to #{email}.")
         |> redirect(to: dashboard_path(conn, :email))
-      {:error, changeset} ->
+      {:error, _changeset} ->
         conn
-        |> put_status(400)
-        |> render_email(user, changeset)
+        |> put_flash(:error, email_error_message(:exists, email))
+        |> redirect(to: dashboard_path(conn, :email))
     end
   end
 
@@ -168,4 +167,5 @@ defmodule HexWeb.DashboardController do
   defp email_error_message(:not_verified, email), do: "Email #{email} not verified."
   defp email_error_message(:already_verified, email), do: "Email #{email} already verified."
   defp email_error_message(:primary, email), do: "Cannot remove primary email #{email}."
+  defp email_error_message(:exists, email), do: "Email #{email} already in use."
 end


### PR DESCRIPTION
I changed this so that its consistent with other error/info messages on the e-mail management page. Also, was wondering if the unique constraint should be on combination of email and verified: true?