### PR TITLE
Remove `tabIndex` in login form

### DIFF
--- a/web/templates/login/show.html.eex
+++ b/web/templates/login/show.html.eex
@@ -5,18 +5,18 @@
 
       <div class="form-group">
         <label for="username">Username or Email</label>
-        <input type="text" class="form-control" name="username" tabindex="10">
+        <input type="text" class="form-control" name="username">
       </div>
 
       <div class="form-group">
         <label for="password">Password</label>
         <span style="float: right;"><a href="<%= password_reset_path(Endpoint, :show) %>">Forgot your password?</a></span>
-        <input type="password" class="form-control" name="password" tabindex="11">
+        <input type="password" class="form-control" name="password">
       </div>
 
       <input type="hidden" name="return" value="<%= @return %>">
 
-      <button type="submit" class="btn btn-primary" tabindex="12">Log in</button>
+      <button type="submit" class="btn btn-primary">Log in</button>
 
       <br><br>
 


### PR DESCRIPTION
Fixes #439.

This removes the `tabIndex` attribute from the text inputs in the login
page. These attributes were not letting users tab through the text
inputs—they got skipped.