### PR TITLE
Add `exact_match` to the Packages#index route.

### DIFF
--- a/web/controllers/package_controller.ex
+++ b/web/controllers/package_controller.ex
@@ -24,6 +24,7 @@ defmodule HexWeb.PackageController do
     package_count = Packages.count(filter)
     page          = HexWeb.Utils.safe_page(page_param, package_count, @packages_per_page)
     packages      = fetch_packages(page, @packages_per_page, filter, sort)
+    exact_match   = Packages.get(search)
 
     render conn, "index.html", [
       title:         "Packages",
@@ -36,7 +37,8 @@ defmodule HexWeb.PackageController do
       page:          page,
       packages:      packages,
       letters:       @letters,
-      downloads:     Packages.packages_downloads(packages, "all")
+      downloads:     Packages.packages_downloads(packages, "all"),
+      exact_match:   exact_match
     ]
   end
 

--- a/web/controllers/package_controller.ex
+++ b/web/controllers/package_controller.ex
@@ -24,7 +24,7 @@ defmodule HexWeb.PackageController do
     package_count = Packages.count(filter)
     page          = HexWeb.Utils.safe_page(page_param, package_count, @packages_per_page)
     packages      = fetch_packages(page, @packages_per_page, filter, sort)
-    exact_match   = Packages.get(search)
+    exact_match   = Packages.get(search || "")
 
     render conn, "index.html", [
       title:         "Packages",

--- a/web/static/css/template/_package-list.scss
+++ b/web/static/css/template/_package-list.scss
@@ -49,7 +49,8 @@
   padding: 40px 20px 10px 20px;
 }
 
-.package-list, .exact-match {
+.package-list,
+.exact-match {
   padding: 20px 0;
   ul {
     list-style: none;
@@ -93,10 +94,9 @@
     }
   }
   h5 {
-    color: #999;
     font-style: italic;
+    color: #999;
   }
-
 }
 
 .exact-match {

--- a/web/static/css/template/_package-list.scss
+++ b/web/static/css/template/_package-list.scss
@@ -49,7 +49,7 @@
   padding: 40px 20px 10px 20px;
 }
 
-.package-list {
+.package-list, .exact-match {
   padding: 20px 0;
   ul {
     list-style: none;
@@ -92,6 +92,16 @@
       }
     }
   }
+  h5 {
+    color: #999;
+    font-style: italic;
+  }
+
+}
+
+.exact-match {
+  border-top: 1px solid #eee;
+  border-bottom: 1px solid #eee;
 }
 
 .pagination-widget {

--- a/web/templates/package/_package.html.eex
+++ b/web/templates/package/_package.html.eex
@@ -1,0 +1,8 @@
+<li>
+  <div class="downloads-info">
+    <span class="download-count"><%= human_number_space(@package_downloads || 0) %></span> <br>
+    downloads
+  </div>
+  <a href="<%= package_path(Endpoint, :show, @package) %>"><%= @package.name %></a> <span class="version"><%= @package.latest_version %></span>
+  <p><%= text_length(@package.meta.description, 140) %></p>
+</li>

--- a/web/templates/package/index.html.eex
+++ b/web/templates/package/index.html.eex
@@ -71,19 +71,11 @@
 
 <div class="clearfix"></div>
 
-
-<%=  if @exact_match do %>
+<%= if @exact_match do %>
   <div class="exact-match">
     <h5>Exact Match:</h5>
     <ul>
-      <li>
-        <div class="downloads-info">
-          <span class="download-count"><%= human_number_space(@downloads[@exact_match.id] || 0) %></span> <br>
-          downloads
-        </div>
-        <a href="<%= package_path(Endpoint, :show, @exact_match) %>"><%= @exact_match.name %></a> <span class="version"><%= @exact_match.latest_version %></span>
-        <p><%= text_length(@exact_match.meta.description, 140) %></p>
-      </li>
+      <%= render "_package.html", package: @exact_match, package_downloads: @downloads[@exact_match.id] %>
     </ul>
   </div>
 <% end %>
@@ -94,14 +86,7 @@
   <% end %>
   <ul>
     <%= for package <- @packages do %>
-      <li>
-        <div class="downloads-info">
-          <span class="download-count"><%= human_number_space(@downloads[package.id] || 0) %></span> <br>
-          downloads
-        </div>
-        <a href="<%= package_path(Endpoint, :show, package) %>"><%= package.name %></a> <span class="version"><%= package.latest_version %></span>
-        <p><%= text_length(package.meta.description, 140) %></p>
-      </li>
+      <%= render "_package.html", package: package, package_downloads: @downloads[package.id] %>
     <% end %>
   </ul>
 </div>

--- a/web/templates/package/index.html.eex
+++ b/web/templates/package/index.html.eex
@@ -77,12 +77,12 @@
     <h5>Exact Match:</h5>
     <ul>
       <li>
-      <div class="downloads-info">
+        <div class="downloads-info">
           <span class="download-count"><%= human_number_space(@downloads[@exact_match.id] || 0) %></span> <br>
           downloads
-      </div>
-      <a href="<%= package_path(Endpoint, :show, @exact_match) %>"><%= @exact_match.name %></a> <span class="version"><%= @exact_match.latest_version %></span>
-      <p><%= text_length(@exact_match.meta.description, 140) %></p>
+        </div>
+        <a href="<%= package_path(Endpoint, :show, @exact_match) %>"><%= @exact_match.name %></a> <span class="version"><%= @exact_match.latest_version %></span>
+        <p><%= text_length(@exact_match.meta.description, 140) %></p>
       </li>
     </ul>
   </div>
@@ -90,18 +90,18 @@
 
 <div class="package-list">
   <%= if @exact_match do %>
-      <h5>Search Results:</h5>
+    <h5>Search Results:</h5>
   <% end %>
   <ul>
     <%= for package <- @packages do %>
-    <li>
-      <div class="downloads-info">
-        <span class="download-count"><%= human_number_space(@downloads[package.id] || 0) %></span> <br>
-        downloads
-      </div>
-      <a href="<%= package_path(Endpoint, :show, package) %>"><%= package.name %></a> <span class="version"><%= package.latest_version %></span>
-      <p><%= text_length(package.meta.description, 140) %></p>
-    </li>
+      <li>
+        <div class="downloads-info">
+          <span class="download-count"><%= human_number_space(@downloads[package.id] || 0) %></span> <br>
+          downloads
+        </div>
+        <a href="<%= package_path(Endpoint, :show, package) %>"><%= package.name %></a> <span class="version"><%= package.latest_version %></span>
+        <p><%= text_length(package.meta.description, 140) %></p>
+      </li>
     <% end %>
   </ul>
 </div>

--- a/web/templates/package/index.html.eex
+++ b/web/templates/package/index.html.eex
@@ -71,7 +71,27 @@
 
 <div class="clearfix"></div>
 
+
+<%=  if @exact_match do %>
+  <div class="exact-match">
+    <h5>Exact Match:</h5>
+    <ul>
+      <li>
+      <div class="downloads-info">
+          <span class="download-count"><%= human_number_space(@downloads[@exact_match.id] || 0) %></span> <br>
+          downloads
+      </div>
+      <a href="<%= package_path(Endpoint, :show, @exact_match) %>"><%= @exact_match.name %></a> <span class="version"><%= @exact_match.latest_version %></span>
+      <p><%= text_length(@exact_match.meta.description, 140) %></p>
+      </li>
+    </ul>
+  </div>
+<% end %>
+
 <div class="package-list">
+  <%= if @exact_match do %>
+      <h5>Search Results:</h5>
+  <% end %>
   <ul>
     <%= for package <- @packages do %>
     <li>


### PR DESCRIPTION
If there exists a package with the exact name as the search query that was entered, will list this package on top of the normal results. Both the `exact match` header and the extra `results` header that was added for clarity are only visible _if_ there is an exact match. Otherwise, the page will look just like it always did.

![packages hex_screenshot](https://cloud.githubusercontent.com/assets/5345745/21194249/8793de2c-c22f-11e6-9506-efa58ba67883.png)

Solves #448 .
