### PR TITLE
CheckNames : Compare UTC Yesterday with UTC current date in SQL Query

### DIFF
--- a/lib/mix/tasks/hexweb/check_names.ex
+++ b/lib/mix/tasks/hexweb/check_names.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Hexweb.CheckNames do
     FROM packages as pall
     CROSS JOIN packages as pnew
     WHERE pall.name <> pnew.name
-      AND pnew.inserted_at >= CURRENT_DATE
+      AND pnew.inserted_at >= CURRENT_DATE AT TIME ZONE 'UTC'
       AND levenshtein(pall.name, pnew.name) <= $1
     ORDER BY pall.name, dist;
     """


### PR DESCRIPTION
This PR addresses the date comparison in the CheckNames task.

If your postgresql database is set to another timezone than UTC.

The find_candidates function will get more or less result than it's supposed to have as we compare different timezones.

In my case I had -5 Timezone VS the rest of the app which seem to use UTC.

Thanks for looking into it !