### PR TITLE
Removed unused mix-task style tags

### DIFF
--- a/web/static/css/template/_docs.scss
+++ b/web/static/css/template/_docs.scss
@@ -1,8 +1,3 @@
-#mix-tasks h3 {
-  padding-top: 90px;
-  margin-top: -90px;
-}
-
 a.anchor {
   position: relative;
   top: -90px;


### PR DESCRIPTION
The #mix-tasks css id is not present in any templates.

I guess we could remove it as it's unused ?