### PR TITLE
Use url-helpers inside controllers (consistency)

### DIFF
--- a/web/controllers/email_controller.ex
+++ b/web/controllers/email_controller.ex
@@ -12,6 +12,6 @@ defmodule HexWeb.EmailController do
 
     conn
     |> put_flash(:custom_location, true)
-    |> redirect(to: "/")
+    |> redirect(to: page_path(HexWeb.Endpoint, :index))
   end
 end

--- a/web/controllers/login_controller.ex
+++ b/web/controllers/login_controller.ex
@@ -34,7 +34,7 @@ defmodule HexWeb.LoginController do
   def delete(conn, _params) do
     conn
     |> delete_session("username")
-    |> redirect(to: "/")
+    |> redirect(to: page_path(HexWeb.Endpoint, :index))
   end
 
   defp render_show(conn) do

--- a/web/controllers/password_controller.ex
+++ b/web/controllers/password_controller.ex
@@ -29,12 +29,12 @@ defmodule HexWeb.PasswordController do
         conn
         |> put_flash(:info, "Your account password has been changed to your new password.")
         |> put_flash(:custom_location, true)
-        |> redirect(to: "/")
+        |> redirect(to: page_path(HexWeb.Endpoint, :index))
       :error ->
         conn
         |> put_flash(:error, "Failed to change your password.")
         |> put_flash(:custom_location, true)
-        |> redirect(to: "/")
+        |> redirect(to: page_path(HexWeb.Endpoint, :index))
       {:error, changeset} ->
         render_show(conn, username, key, changeset)
     end

--- a/web/controllers/signup_controller.ex
+++ b/web/controllers/signup_controller.ex
@@ -11,7 +11,7 @@ defmodule HexWeb.SignupController do
         conn
         |> put_flash(:info, "A confirmation email has been sent, you will have access to your account shortly.")
         |> put_flash(:custom_location, true)
-        |> redirect(to: "/")
+        |> redirect(to: page_path(HexWeb.Endpoint, :index))
       {:error, changeset} ->
         conn
         |> put_status(400)

--- a/web/controllers/test_controller.ex
+++ b/web/controllers/test_controller.ex
@@ -45,7 +45,7 @@ defmodule HexWeb.TestController do
   end
 
   def docs_sitemap(conn, _params) do
-    HexWeb.Store.get(nil, :docs_bucket, "sitemap.xml", [])
+    HexWeb.Store.get(nil, :docs_bucket, sitemap_path(HexWeb.Endpoint, :sitemap), [])
     |> send_object(conn)
   end
 


### PR DESCRIPTION
Hi,

I have noticed that in most part of the app, phoenix url helpers are used to get the url mappings.

This PR updates the remaining controllers that had hard-coded url.

Thanks.