### PR TITLE
Remove parentheses deprecations & missing interfaces in registry

### DIFF
--- a/lib/hex_web/mail.ex
+++ b/lib/hex_web/mail.ex
@@ -5,7 +5,7 @@ defmodule HexWeb.Mail do
   def owner_added(package, owners, owner) do
     owner_email = hd(owner.emails).email
 
-    new_email
+    new_email()
     |> to(owners)
     |> from(source())
     |> subject("Hex.pm - Owner added")
@@ -18,7 +18,7 @@ defmodule HexWeb.Mail do
   def owner_removed(package, owners, owner) do
     owner_email = hd(owner.emails).email
 
-    new_email
+    new_email()
     |> to(owners)
     |> from(source())
     |> subject("Hex.pm - Owner removed")
@@ -29,7 +29,7 @@ defmodule HexWeb.Mail do
   end
 
   def verification(user, email) do
-    new_email
+    new_email()
     |> to(user)
     |> from(source())
     |> subject("Hex.pm - Email verification")
@@ -40,7 +40,7 @@ defmodule HexWeb.Mail do
   end
 
   def user_confirmed(user) do
-    new_email
+    new_email()
     |> to(user)
     |> from(source())
     |> subject("Hex.pm - Account confirmed")
@@ -48,7 +48,7 @@ defmodule HexWeb.Mail do
   end
 
   def password_reset_request(user) do
-    new_email
+    new_email()
     |> to(user)
     |> from(source())
     |> subject("Hex.pm - Password reset request")
@@ -59,7 +59,7 @@ defmodule HexWeb.Mail do
 
   def typosquat_candidates([], _), do: :ok
   def typosquat_candidate(candidates, threshold) do
-    new_email
+    new_email()
     |> to(Application.get_env(:hex_web, :support_email))
     |> from(source())
     |> subject("Hex.pm - Typosquat candidates")

--- a/lib/hex_web/registry_db.ex
+++ b/lib/hex_web/registry_db.ex
@@ -115,4 +115,13 @@ defmodule HexWeb.RegistryDB do
 
   def get_build_tools(_name, _package, _version),
     do: raise "not implemented"
+
+  def retired(_name, _package, _version),
+    do: raise "not implemented"
+
+  def tarball_etag(_name, _package, _version),
+    do: raise "not implemented"
+
+  def tarball_etag(_name, _package, _version, _String_t),
+    do: raise "not implemented"
 end


### PR DESCRIPTION
This PR covers 2 small points to be ready with Elixir 1.4.

- Remove the ()s deprecations that were present in mail.ex
- Add the missing callbacks as non-implemented in registry_db.ex

Thanks for looking into it!

Compilations Errors related to changes :

```
warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  lib/hex_web/mail.ex:8

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  lib/hex_web/mail.ex:21

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  lib/hex_web/mail.ex:32

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  lib/hex_web/mail.ex:43

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  lib/hex_web/mail.ex:51

warning: variable "new_email" does not exist and is being expanded to "new_email()", please use parentheses to remove the ambiguity or change the variable name
  lib/hex_web/mail.ex:62

warning: undefined behaviour function retired/3 (for behaviour Hex.Registry)
  lib/hex_web/registry_db.ex:1

warning: undefined behaviour function tarball_etag/3 (for behaviour Hex.Registry)
  lib/hex_web/registry_db.ex:1

warning: undefined behaviour function tarball_etag/4 (for behaviour Hex.Registry)
  lib/hex_web/registry_db.ex:1
```