### PR TITLE
CSS: Don't cut off descenders in dependencies list

### DIFF
--- a/web/static/css/template/_package-view.scss
+++ b/web/static/css/template/_package-view.scss
@@ -147,9 +147,9 @@
     margin: 0 0 10px;
     overflow: hidden;
     font-weight: 300;
+    line-height: 1.06;  // Just enough for e.g. the bottom of a "g" not to be cut off.
     color: #000;
     text-overflow: ellipsis;
-    line-height: 1.06;  // Just enough for e.g. the bottom of a "g" not to be cut off.
   }
 }
 

--- a/web/static/css/template/_package-view.scss
+++ b/web/static/css/template/_package-view.scss
@@ -149,6 +149,7 @@
     font-weight: 300;
     color: #000;
     text-overflow: ellipsis;
+    line-height: 1.06;  // Just enough for e.g. the bottom of a "g" not to be cut off.
   }
 }
 


### PR DESCRIPTION
The cut-off is caused by the "overflow: hidden" introduced in https://github.com/hexpm/hex_web/commit/c8f3a71e6d8ccc35991a443691ff0b794eb496a9.

Chrome on Mac OS before this change, note the "g":

![screenshot 2017-02-25 13 54 16](https://cloud.githubusercontent.com/assets/216/23331644/f2b3046a-fb61-11e6-96a8-51162c7993fe.png)

After:

![screenshot 2017-02-25 13 54 47](https://cloud.githubusercontent.com/assets/216/23331648/fc76c414-fb61-11e6-93e4-1894ff848124.png)

Screenshots are from this page: https://hex.pm/packages/ectoo